### PR TITLE
 Extract direct enqueue and stage execution loops into internal runtime

### DIFF
--- a/internal/runtime/direct_enqueue.go
+++ b/internal/runtime/direct_enqueue.go
@@ -1,0 +1,40 @@
+package runtime
+
+import "context"
+
+type DirectEnqueueConfig[J any] struct {
+	Ctx                  context.Context
+	StageName            string
+	LookupQueue          func(stage string) (chan J, bool)
+	BuildStageNotFound   func(stage string) error
+	BeforeSchedule       func()
+	OnCanceledAfterBuild func()
+	BuildJob             func(stage string) J
+}
+
+// EnqueueDirect resolves the stage queue, builds the job, and enqueues it
+// with context-aware cancellation behavior.
+func EnqueueDirect[J any](cfg DirectEnqueueConfig[J]) error {
+	stageQueue, ok := cfg.LookupQueue(cfg.StageName)
+	if !ok {
+		return cfg.BuildStageNotFound(cfg.StageName)
+	}
+	if cfg.Ctx.Err() != nil {
+		return cfg.Ctx.Err()
+	}
+
+	if cfg.BeforeSchedule != nil {
+		cfg.BeforeSchedule()
+	}
+	job := cfg.BuildJob(cfg.StageName)
+
+	select {
+	case <-cfg.Ctx.Done():
+		if cfg.OnCanceledAfterBuild != nil {
+			cfg.OnCanceledAfterBuild()
+		}
+		return cfg.Ctx.Err()
+	case stageQueue <- job:
+		return nil
+	}
+}

--- a/internal/runtime/direct_enqueue_test.go
+++ b/internal/runtime/direct_enqueue_test.go
@@ -1,0 +1,84 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+func TestEnqueueDirect_StageNotFound(t *testing.T) {
+	want := errors.New("missing")
+	err := EnqueueDirect(DirectEnqueueConfig[int]{
+		Ctx:       context.Background(),
+		StageName: "a",
+		LookupQueue: func(stage string) (chan int, bool) {
+			return nil, false
+		},
+		BuildStageNotFound: func(stage string) error { return want },
+		BuildJob: func(stage string) int {
+			return 1
+		},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v want=%v", err, want)
+	}
+}
+
+func TestEnqueueDirect_CancelAfterBuild(t *testing.T) {
+	q := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	var canceled atomic.Int64
+	var scheduled atomic.Int64
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- EnqueueDirect(DirectEnqueueConfig[int]{
+			Ctx:       ctx,
+			StageName: "a",
+			LookupQueue: func(stage string) (chan int, bool) {
+				return q, true
+			},
+			BuildStageNotFound: func(stage string) error { return errors.New("missing") },
+			BeforeSchedule: func() {
+				scheduled.Add(1)
+				cancel()
+			},
+			OnCanceledAfterBuild: func() {
+				canceled.Add(1)
+			},
+			BuildJob: func(stage string) int { return 1 },
+		})
+	}()
+
+	err := <-errCh
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err=%v want context.Canceled", err)
+	}
+	if scheduled.Load() != 1 {
+		t.Fatalf("scheduled=%d want=1", scheduled.Load())
+	}
+	if canceled.Load() != 1 {
+		t.Fatalf("canceled=%d want=1", canceled.Load())
+	}
+}
+
+func TestEnqueueDirect_Success(t *testing.T) {
+	q := make(chan int, 1)
+	err := EnqueueDirect(DirectEnqueueConfig[int]{
+		Ctx:       context.Background(),
+		StageName: "a",
+		LookupQueue: func(stage string) (chan int, bool) {
+			return q, true
+		},
+		BuildStageNotFound: func(stage string) error { return errors.New("missing") },
+		BuildJob:           func(stage string) int { return 7 },
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	got := <-q
+	if got != 7 {
+		t.Fatalf("got=%d want=7", got)
+	}
+}

--- a/internal/runtime/stage_execute.go
+++ b/internal/runtime/stage_execute.go
@@ -1,0 +1,144 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+type StageExecutionPolicy struct {
+	MaxAttempts int
+	Backoff     time.Duration
+	Timeout     time.Duration
+}
+
+type StageExecutionResult[T any] struct {
+	Out        []T
+	Err        error
+	AckOnError bool
+}
+
+type StageExecutionConfig[T any] struct {
+	Ctx          context.Context
+	Stage        string
+	Input        T
+	Policy       StageExecutionPolicy
+	Process      func(context.Context, T) ([]T, error)
+	IsContextErr func(error) bool
+	WaitRate     func(context.Context) error
+
+	OnStageStart   func(startedAt time.Time)
+	OnStageFinish  func(outCount int, startedAt, finishedAt time.Time)
+	OnStageError   func(startedAt, finishedAt time.Time, err error)
+	OnAttemptStart func(attempt int, startedAt time.Time)
+	OnAttemptError func(attempt int, startedAt, finishedAt time.Time, err error)
+	OnRetry        func(attempt int, err error, backoff time.Duration, at time.Time)
+	OnTimeout      func(attempt int, startedAt time.Time, timeout time.Duration, at time.Time)
+	OnExhausted    func(attempt int, err error, at time.Time)
+}
+
+func ExecuteStageWithPolicy[T any](cfg StageExecutionConfig[T]) StageExecutionResult[T] {
+	if cfg.WaitRate != nil {
+		if err := cfg.WaitRate(cfg.Ctx); err != nil {
+			return StageExecutionResult[T]{
+				Err:        err,
+				AckOnError: false,
+			}
+		}
+	}
+
+	policy := cfg.Policy
+	if policy.MaxAttempts <= 0 {
+		policy.MaxAttempts = 1
+	}
+
+	stageStart := time.Now()
+	if cfg.OnStageStart != nil {
+		cfg.OnStageStart(stageStart)
+	}
+
+	var (
+		out []T
+		err error
+	)
+	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+		attemptCtx := cfg.Ctx
+		cancel := func() {}
+		if policy.Timeout > 0 {
+			attemptCtx, cancel = context.WithTimeout(cfg.Ctx, policy.Timeout)
+		}
+
+		attemptStart := time.Now()
+		if cfg.OnAttemptStart != nil {
+			cfg.OnAttemptStart(attempt, attemptStart)
+		}
+		out, err = cfg.Process(attemptCtx, cfg.Input)
+		attemptFinish := time.Now()
+		cancel()
+
+		if err == nil {
+			if cfg.OnStageFinish != nil {
+				cfg.OnStageFinish(len(out), stageStart, attemptFinish)
+			}
+			return StageExecutionResult[T]{
+				Out:        out,
+				Err:        nil,
+				AckOnError: false,
+			}
+		}
+
+		if cfg.OnAttemptError != nil {
+			cfg.OnAttemptError(attempt, attemptStart, attemptFinish, err)
+		}
+		if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) && cfg.OnTimeout != nil {
+			cfg.OnTimeout(attempt, attemptStart, policy.Timeout, attemptFinish)
+		}
+
+		// stop immediately on run cancellation
+		if cfg.Ctx.Err() != nil {
+			if cfg.IsContextErr != nil && !cfg.IsContextErr(err) {
+				if cfg.OnStageError != nil {
+					cfg.OnStageError(stageStart, attemptFinish, err)
+				}
+				return StageExecutionResult[T]{
+					Err:        err,
+					AckOnError: false,
+				}
+			}
+			return StageExecutionResult[T]{
+				Err:        cfg.Ctx.Err(),
+				AckOnError: false,
+			}
+		}
+
+		// no retries left
+		if attempt == policy.MaxAttempts {
+			if cfg.OnExhausted != nil {
+				cfg.OnExhausted(attempt, err, attemptFinish)
+			}
+			if cfg.OnStageError != nil {
+				cfg.OnStageError(stageStart, attemptFinish, err)
+			}
+			return StageExecutionResult[T]{
+				Err:        err,
+				AckOnError: true,
+			}
+		}
+
+		if cfg.OnRetry != nil {
+			cfg.OnRetry(attempt, err, policy.Backoff, attemptFinish)
+		}
+		if policy.Backoff > 0 {
+			select {
+			case <-cfg.Ctx.Done():
+				return StageExecutionResult[T]{
+					Err:        cfg.Ctx.Err(),
+					AckOnError: false,
+				}
+			case <-time.After(policy.Backoff):
+			}
+		}
+	}
+
+	return StageExecutionResult[T]{}
+}

--- a/internal/runtime/stage_execute_test.go
+++ b/internal/runtime/stage_execute_test.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestExecuteStageWithPolicy_ExhaustedSetsAckOnError(t *testing.T) {
+	cfg := StageExecutionConfig[int]{
+		Ctx:   context.Background(),
+		Stage: "s",
+		Input: 1,
+		Policy: StageExecutionPolicy{
+			MaxAttempts: 2,
+			Backoff:     0,
+		},
+		Process: func(ctx context.Context, in int) ([]int, error) {
+			return nil, errors.New("boom")
+		},
+		IsContextErr: func(err error) bool {
+			return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		},
+	}
+
+	res := ExecuteStageWithPolicy(cfg)
+	if res.Err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !res.AckOnError {
+		t.Fatal("expected AckOnError=true")
+	}
+}
+
+func TestExecuteStageWithPolicy_ContextCanceledNoAck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := StageExecutionConfig[int]{
+		Ctx:   ctx,
+		Stage: "s",
+		Input: 1,
+		Policy: StageExecutionPolicy{
+			MaxAttempts: 1,
+		},
+		Process: func(ctx context.Context, in int) ([]int, error) {
+			return nil, context.Canceled
+		},
+		IsContextErr: func(err error) bool {
+			return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		},
+	}
+
+	res := ExecuteStageWithPolicy(cfg)
+	if !errors.Is(res.Err, context.Canceled) {
+		t.Fatalf("err=%v, want context.Canceled", res.Err)
+	}
+	if res.AckOnError {
+		t.Fatal("expected AckOnError=false")
+	}
+}
+
+func TestExecuteStageWithPolicy_RetryThenSuccess(t *testing.T) {
+	attempts := 0
+	cfg := StageExecutionConfig[int]{
+		Ctx:   context.Background(),
+		Stage: "s",
+		Input: 2,
+		Policy: StageExecutionPolicy{
+			MaxAttempts: 3,
+			Backoff:     1 * time.Millisecond,
+		},
+		Process: func(ctx context.Context, in int) ([]int, error) {
+			attempts++
+			if attempts < 2 {
+				return nil, errors.New("transient")
+			}
+			return []int{in + 1}, nil
+		},
+		IsContextErr: func(err error) bool {
+			return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+		},
+	}
+
+	res := ExecuteStageWithPolicy(cfg)
+	if res.Err != nil {
+		t.Fatalf("unexpected err: %v", res.Err)
+	}
+	if res.AckOnError {
+		t.Fatal("expected AckOnError=false")
+	}
+	if len(res.Out) != 1 || res.Out[0] != 3 {
+		t.Fatalf("unexpected out: %#v", res.Out)
+	}
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -256,237 +256,235 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 	startStagePools(runCtx, stages, runOpts, poolsByStage, jobsByStage, &poolErrWG, recordErr)
 
 	enqueueDirect = func(stageName string, in T, hops int, frontierEntryID uint64, frontierEntryAttempt int) error {
-		stageJobs, ok := jobsByStage[stageName]
-		if !ok {
-			return StageNotFound(stageName)
-		}
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
+		return iruntime.EnqueueDirect(iruntime.DirectEnqueueConfig[Job]{
+			Ctx:       ctx,
+			StageName: stageName,
+			LookupQueue: func(stage string) (chan Job, bool) {
+				q, ok := jobsByStage[stage]
+				return q, ok
+			},
+			BuildStageNotFound: StageNotFound,
+			BeforeSchedule: func() {
+				tasksWG.Add(1)
+			},
+			OnCanceledAfterBuild: func() {
+				tasksWG.Done()
+			},
+			BuildJob: func(stage string) Job {
+				return Job{
+					Name: stage, // Kill per-job fmt.Sprintf in hot path
+					Run: func(_ context.Context) error {
+						defer tasksWG.Done()
+						if frontierEntryID != 0 {
+							defer frontierOutstandingWG.Done()
+						}
+						if runCtx.Err() != nil {
+							return runCtx.Err()
+						}
 
-		tasksWG.Add(1)
-		job := Job{
-			Name: stageName, // Kill per-job fmt.Sprintf in hot path
-			Run: func(_ context.Context) error {
-				defer tasksWG.Done()
-				if frontierEntryID != 0 {
-					defer frontierOutstandingWG.Done()
-				}
-				if runCtx.Err() != nil {
-					return runCtx.Err()
-				}
+						stageDef := stages[stage]
 
-				stage := stages[stageName]
+						if limiter, ok := limiters[stage]; ok {
+							if err := limiter.Wait(runCtx); err != nil {
+								return fmt.Errorf("stage %s: rate limit wait: %w", stage, err)
+							}
+						}
 
-				if limiter, ok := limiters[stageName]; ok {
-					if err := limiter.Wait(runCtx); err != nil {
-						return fmt.Errorf("stage %s: rate limit wait: %w", stageName, err)
-					}
-				}
+						policy, hasPolicy := runOpts.StagePolicies[stage]
+						if !hasPolicy {
+							policy = StagePolicy{MaxAttempts: 1}
+						}
+						if policy.MaxAttempts <= 0 {
+							policy.MaxAttempts = 1
+						}
 
-				policy, hasPolicy := runOpts.StagePolicies[stageName]
-				if !hasPolicy {
-					policy = StagePolicy{MaxAttempts: 1}
-				}
-				if policy.MaxAttempts <= 0 {
-					policy.MaxAttempts = 1
-				}
-
-				stageStart := time.Now()
-				iruntime.Call2(runOpts.Hooks.StageStart, runCtx, StageStartEvent[T]{
-					RunID:     runID,
-					Stage:     stageName,
-					Input:     in,
-					StartedAt: stageStart,
-				})
-
-				var (
-					out []T
-					err error
-				)
-
-				for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
-					attemptCtx := runCtx
-					var cancel context.CancelFunc = func() {}
-					if policy.Timeout > 0 {
-						attemptCtx, cancel = context.WithTimeout(runCtx, policy.Timeout)
-					}
-
-					attemptStart := time.Now()
-					iruntime.Call2(runOpts.Hooks.StageAttemptStart, runCtx, StageAttemptStartEvent[T]{
-						RunID:     runID,
-						Stage:     stageName,
-						Input:     in,
-						Attempt:   attempt,
-						StartedAt: attemptStart,
-					})
-					out, err = stage.Process(attemptCtx, in)
-					attemptFinish := time.Now()
-					attemptDuration := attemptFinish.Sub(attemptStart)
-					cancel()
-
-					if err == nil {
-						iruntime.Call2(runOpts.Hooks.StageFinish, runCtx, StageFinishEvent[T]{
-							RunID:      runID,
-							Stage:      stageName,
-							Input:      in,
-							OutCount:   len(out),
-							StartedAt:  stageStart,
-							FinishedAt: attemptFinish,
-							Duration:   attemptFinish.Sub(stageStart),
-						})
-						break
-					}
-
-					iruntime.Call2(runOpts.Hooks.StageAttemptError, runCtx, StageAttemptErrorEvent[T]{
-						RunID:      runID,
-						Stage:      stageName,
-						Input:      in,
-						Attempt:    attempt,
-						StartedAt:  attemptStart,
-						FinishedAt: attemptFinish,
-						Duration:   attemptDuration,
-						Err:        err,
-					})
-					if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
-						iruntime.Call2(runOpts.Hooks.StageTimeout, runCtx, StageTimeoutEvent[T]{
+						stageStart := time.Now()
+						iruntime.Call2(runOpts.Hooks.StageStart, runCtx, StageStartEvent[T]{
 							RunID:     runID,
-							Stage:     stageName,
+							Stage:     stage,
 							Input:     in,
-							Attempt:   attempt,
-							StartedAt: attemptStart,
-							Timeout:   policy.Timeout,
-							At:        attemptFinish,
+							StartedAt: stageStart,
 						})
-					}
 
-					// stop immediately on run cancellation
-					if runCtx.Err() != nil {
-						if !isContextErr(err) {
-							iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
+						var (
+							out []T
+							err error
+						)
+
+						for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+							attemptCtx := runCtx
+							var cancel context.CancelFunc = func() {}
+							if policy.Timeout > 0 {
+								attemptCtx, cancel = context.WithTimeout(runCtx, policy.Timeout)
+							}
+
+							attemptStart := time.Now()
+							iruntime.Call2(runOpts.Hooks.StageAttemptStart, runCtx, StageAttemptStartEvent[T]{
+								RunID:     runID,
+								Stage:     stage,
+								Input:     in,
+								Attempt:   attempt,
+								StartedAt: attemptStart,
+							})
+							out, err = stageDef.Process(attemptCtx, in)
+							attemptFinish := time.Now()
+							attemptDuration := attemptFinish.Sub(attemptStart)
+							cancel()
+
+							if err == nil {
+								iruntime.Call2(runOpts.Hooks.StageFinish, runCtx, StageFinishEvent[T]{
+									RunID:      runID,
+									Stage:      stage,
+									Input:      in,
+									OutCount:   len(out),
+									StartedAt:  stageStart,
+									FinishedAt: attemptFinish,
+									Duration:   attemptFinish.Sub(stageStart),
+								})
+								break
+							}
+
+							iruntime.Call2(runOpts.Hooks.StageAttemptError, runCtx, StageAttemptErrorEvent[T]{
 								RunID:      runID,
-								Stage:      stageName,
+								Stage:      stage,
 								Input:      in,
-								StartedAt:  stageStart,
+								Attempt:    attempt,
+								StartedAt:  attemptStart,
 								FinishedAt: attemptFinish,
-								Duration:   attemptFinish.Sub(stageStart),
+								Duration:   attemptDuration,
 								Err:        err,
 							})
-							return fmt.Errorf("stage %s: %w", stageName, err)
+							if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+								iruntime.Call2(runOpts.Hooks.StageTimeout, runCtx, StageTimeoutEvent[T]{
+									RunID:     runID,
+									Stage:     stage,
+									Input:     in,
+									Attempt:   attempt,
+									StartedAt: attemptStart,
+									Timeout:   policy.Timeout,
+									At:        attemptFinish,
+								})
+							}
+
+							// stop immediately on run cancellation
+							if runCtx.Err() != nil {
+								if !isContextErr(err) {
+									iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
+										RunID:      runID,
+										Stage:      stage,
+										Input:      in,
+										StartedAt:  stageStart,
+										FinishedAt: attemptFinish,
+										Duration:   attemptFinish.Sub(stageStart),
+										Err:        err,
+									})
+									return fmt.Errorf("stage %s: %w", stage, err)
+								}
+								return runCtx.Err()
+							}
+
+							// no retries left
+							if attempt == policy.MaxAttempts {
+								iruntime.Call2(runOpts.Hooks.StageExhausted, runCtx, StageExhaustedEvent[T]{
+									RunID:    runID,
+									Stage:    stage,
+									Input:    in,
+									Attempts: attempt,
+									Err:      err,
+									At:       attemptFinish,
+								})
+								iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
+									RunID:      runID,
+									Stage:      stage,
+									Input:      in,
+									StartedAt:  stageStart,
+									FinishedAt: attemptFinish,
+									Duration:   attemptFinish.Sub(stageStart),
+									Err:        err,
+								})
+								break
+							}
+
+							iruntime.Call2(runOpts.Hooks.StageRetry, runCtx, StageRetryEvent[T]{
+								RunID:   runID,
+								Stage:   stage,
+								Input:   in,
+								Attempt: attempt,
+								Err:     err,
+								Backoff: policy.Backoff,
+								At:      attemptFinish,
+							})
+
+							// context-aware backoff
+							if policy.Backoff > 0 {
+								select {
+								case <-runCtx.Done():
+									return runCtx.Err()
+								case <-time.After(policy.Backoff):
+								}
+							}
 						}
-						return runCtx.Err()
-					}
 
-					// no retries left
-					if attempt == policy.MaxAttempts {
-						iruntime.Call2(runOpts.Hooks.StageExhausted, runCtx, StageExhaustedEvent[T]{
-							RunID:    runID,
-							Stage:    stageName,
-							Input:    in,
-							Attempts: attempt,
-							Err:      err,
-							At:       attemptFinish,
-						})
-						iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
-							RunID:      runID,
-							Stage:      stageName,
-							Input:      in,
-							StartedAt:  stageStart,
-							FinishedAt: attemptFinish,
-							Duration:   attemptFinish.Sub(stageStart),
-							Err:        err,
-						})
-						break
-					}
-
-					iruntime.Call2(runOpts.Hooks.StageRetry, runCtx, StageRetryEvent[T]{
-						RunID:   runID,
-						Stage:   stageName,
-						Input:   in,
-						Attempt: attempt,
-						Err:     err,
-						Backoff: policy.Backoff,
-						At:      attemptFinish,
-					})
-
-					// context-aware backoff
-					if policy.Backoff > 0 {
-						select {
-						case <-runCtx.Done():
-							return runCtx.Err()
-						case <-time.After(policy.Backoff):
+						if err != nil {
+							if frontierEntryID != 0 {
+								ackErr := fs.Ack(frontierEntryID)
+								if ackErr != nil {
+									return fmt.Errorf("stage %s: %w", stage, errors.Join(err, fmt.Errorf("frontier ack after stage error: %w", ackErr)))
+								}
+								iruntime.Call2(runOpts.Hooks.FrontierAck, runCtx, FrontierAckEvent[T]{
+									RunID:   runID,
+									EntryID: frontierEntryID,
+									Stage:   stage,
+									Input:   in,
+									Hops:    hops,
+									Attempt: frontierEntryAttempt,
+									At:      time.Now(),
+								})
+							}
+							return fmt.Errorf("stage %s: %w", stage, err)
 						}
-					}
-				}
 
-				if err != nil {
-					if frontierEntryID != 0 {
-						ackErr := fs.Ack(frontierEntryID)
-						if ackErr != nil {
-							return fmt.Errorf("stage %s: %w", stageName, errors.Join(err, fmt.Errorf("frontier ack after stage error: %w", ackErr)))
+						resultsMu.Lock()
+						results[stage] = append(results[stage], out...)
+						resultsMu.Unlock()
+
+						for _, item := range out {
+							for _, sinkCh := range sinksByStage[stage] {
+								select {
+								case <-runCtx.Done():
+									return runCtx.Err()
+								case sinkCh <- item:
+								}
+							}
 						}
-						iruntime.Call2(runOpts.Hooks.FrontierAck, runCtx, FrontierAckEvent[T]{
-							RunID:   runID,
-							EntryID: frontierEntryID,
-							Stage:   stageName,
-							Input:   in,
-							Hops:    hops,
-							Attempt: frontierEntryAttempt,
-							At:      time.Now(),
-						})
-					}
-					return fmt.Errorf("stage %s: %w", stageName, err)
-				}
 
-				resultsMu.Lock()
-				results[stageName] = append(results[stageName], out...)
-				resultsMu.Unlock()
-
-				for _, item := range out {
-					for _, sinkCh := range sinksByStage[stageName] {
-						select {
-						case <-runCtx.Done():
-							return runCtx.Err()
-						case sinkCh <- item:
+						for _, nextStage := range edges[stage] {
+							for _, item := range out {
+								if err := enqueueGuarded(nextStage, item, hops+1); err != nil {
+									return fmt.Errorf("enqueue to %s: %w", nextStage, err)
+								}
+							}
 						}
-					}
-				}
 
-				for _, nextStage := range edges[stageName] {
-					for _, item := range out {
-						if err := enqueueGuarded(nextStage, item, hops+1); err != nil {
-							return fmt.Errorf("enqueue to %s: %w", nextStage, err)
+						if frontierEntryID != 0 {
+							if err := fs.Ack(frontierEntryID); err != nil {
+								return fmt.Errorf("frontier ack: %w", err)
+							}
+							iruntime.Call2(runOpts.Hooks.FrontierAck, runCtx, FrontierAckEvent[T]{
+								RunID:   runID,
+								EntryID: frontierEntryID,
+								Stage:   stage,
+								Input:   in,
+								Hops:    hops,
+								Attempt: frontierEntryAttempt,
+								At:      time.Now(),
+							})
 						}
-					}
+						return nil
+					},
 				}
-
-				if frontierEntryID != 0 {
-					if err := fs.Ack(frontierEntryID); err != nil {
-						return fmt.Errorf("frontier ack: %w", err)
-					}
-					iruntime.Call2(runOpts.Hooks.FrontierAck, runCtx, FrontierAckEvent[T]{
-						RunID:   runID,
-						EntryID: frontierEntryID,
-						Stage:   stageName,
-						Input:   in,
-						Hops:    hops,
-						Attempt: frontierEntryAttempt,
-						At:      time.Now(),
-					})
-				}
-				return nil
 			},
-		}
-
-		select {
-		case <-ctx.Done():
-			tasksWG.Done()
-			return ctx.Err()
-
-		case stageJobs <- job:
-			return nil
-		}
-
+		})
 	}
 
 	var schedulerWG sync.WaitGroup

--- a/pipeline.go
+++ b/pipeline.go
@@ -283,150 +283,116 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 						}
 
 						stageDef := stages[stage]
-
-						if limiter, ok := limiters[stage]; ok {
-							if err := limiter.Wait(runCtx); err != nil {
-								return fmt.Errorf("stage %s: rate limit wait: %w", stage, err)
-							}
-						}
-
 						policy, hasPolicy := runOpts.StagePolicies[stage]
 						if !hasPolicy {
 							policy = StagePolicy{MaxAttempts: 1}
 						}
-						if policy.MaxAttempts <= 0 {
-							policy.MaxAttempts = 1
-						}
 
-						stageStart := time.Now()
-						iruntime.Call2(runOpts.Hooks.StageStart, runCtx, StageStartEvent[T]{
-							RunID:     runID,
-							Stage:     stage,
-							Input:     in,
-							StartedAt: stageStart,
-						})
-
-						var (
-							out []T
-							err error
-						)
-
-						for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
-							attemptCtx := runCtx
-							var cancel context.CancelFunc = func() {}
-							if policy.Timeout > 0 {
-								attemptCtx, cancel = context.WithTimeout(runCtx, policy.Timeout)
-							}
-
-							attemptStart := time.Now()
-							iruntime.Call2(runOpts.Hooks.StageAttemptStart, runCtx, StageAttemptStartEvent[T]{
-								RunID:     runID,
-								Stage:     stage,
-								Input:     in,
-								Attempt:   attempt,
-								StartedAt: attemptStart,
-							})
-							out, err = stageDef.Process(attemptCtx, in)
-							attemptFinish := time.Now()
-							attemptDuration := attemptFinish.Sub(attemptStart)
-							cancel()
-
-							if err == nil {
+						execResult := iruntime.ExecuteStageWithPolicy(iruntime.StageExecutionConfig[T]{
+							Ctx:    runCtx,
+							Stage:  stage,
+							Input:  in,
+							Policy: iruntime.StageExecutionPolicy{MaxAttempts: policy.MaxAttempts, Backoff: policy.Backoff, Timeout: policy.Timeout},
+							Process: func(attemptCtx context.Context, item T) ([]T, error) {
+								return stageDef.Process(attemptCtx, item)
+							},
+							IsContextErr: isContextErr,
+							WaitRate: func(waitCtx context.Context) error {
+								if limiter, ok := limiters[stage]; ok {
+									if err := limiter.Wait(waitCtx); err != nil {
+										return fmt.Errorf("rate limit wait: %w", err)
+									}
+								}
+								return nil
+							},
+							OnStageStart: func(startedAt time.Time) {
+								iruntime.Call2(runOpts.Hooks.StageStart, runCtx, StageStartEvent[T]{
+									RunID:     runID,
+									Stage:     stage,
+									Input:     in,
+									StartedAt: startedAt,
+								})
+							},
+							OnStageFinish: func(outCount int, startedAt, finishedAt time.Time) {
 								iruntime.Call2(runOpts.Hooks.StageFinish, runCtx, StageFinishEvent[T]{
 									RunID:      runID,
 									Stage:      stage,
 									Input:      in,
-									OutCount:   len(out),
-									StartedAt:  stageStart,
-									FinishedAt: attemptFinish,
-									Duration:   attemptFinish.Sub(stageStart),
+									OutCount:   outCount,
+									StartedAt:  startedAt,
+									FinishedAt: finishedAt,
+									Duration:   finishedAt.Sub(startedAt),
 								})
-								break
-							}
-
-							iruntime.Call2(runOpts.Hooks.StageAttemptError, runCtx, StageAttemptErrorEvent[T]{
-								RunID:      runID,
-								Stage:      stage,
-								Input:      in,
-								Attempt:    attempt,
-								StartedAt:  attemptStart,
-								FinishedAt: attemptFinish,
-								Duration:   attemptDuration,
-								Err:        err,
-							})
-							if errors.Is(attemptCtx.Err(), context.DeadlineExceeded) {
+							},
+							OnStageError: func(startedAt, finishedAt time.Time, err error) {
+								iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
+									RunID:      runID,
+									Stage:      stage,
+									Input:      in,
+									StartedAt:  startedAt,
+									FinishedAt: finishedAt,
+									Duration:   finishedAt.Sub(startedAt),
+									Err:        err,
+								})
+							},
+							OnAttemptStart: func(attempt int, startedAt time.Time) {
+								iruntime.Call2(runOpts.Hooks.StageAttemptStart, runCtx, StageAttemptStartEvent[T]{
+									RunID:     runID,
+									Stage:     stage,
+									Input:     in,
+									Attempt:   attempt,
+									StartedAt: startedAt,
+								})
+							},
+							OnAttemptError: func(attempt int, startedAt, finishedAt time.Time, err error) {
+								iruntime.Call2(runOpts.Hooks.StageAttemptError, runCtx, StageAttemptErrorEvent[T]{
+									RunID:      runID,
+									Stage:      stage,
+									Input:      in,
+									Attempt:    attempt,
+									StartedAt:  startedAt,
+									FinishedAt: finishedAt,
+									Duration:   finishedAt.Sub(startedAt),
+									Err:        err,
+								})
+							},
+							OnRetry: func(attempt int, err error, backoff time.Duration, at time.Time) {
+								iruntime.Call2(runOpts.Hooks.StageRetry, runCtx, StageRetryEvent[T]{
+									RunID:   runID,
+									Stage:   stage,
+									Input:   in,
+									Attempt: attempt,
+									Err:     err,
+									Backoff: backoff,
+									At:      at,
+								})
+							},
+							OnTimeout: func(attempt int, startedAt time.Time, timeout time.Duration, at time.Time) {
 								iruntime.Call2(runOpts.Hooks.StageTimeout, runCtx, StageTimeoutEvent[T]{
 									RunID:     runID,
 									Stage:     stage,
 									Input:     in,
 									Attempt:   attempt,
-									StartedAt: attemptStart,
-									Timeout:   policy.Timeout,
-									At:        attemptFinish,
+									StartedAt: startedAt,
+									Timeout:   timeout,
+									At:        at,
 								})
-							}
-
-							// stop immediately on run cancellation
-							if runCtx.Err() != nil {
-								if !isContextErr(err) {
-									iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
-										RunID:      runID,
-										Stage:      stage,
-										Input:      in,
-										StartedAt:  stageStart,
-										FinishedAt: attemptFinish,
-										Duration:   attemptFinish.Sub(stageStart),
-										Err:        err,
-									})
-									return fmt.Errorf("stage %s: %w", stage, err)
-								}
-								return runCtx.Err()
-							}
-
-							// no retries left
-							if attempt == policy.MaxAttempts {
+							},
+							OnExhausted: func(attempt int, err error, at time.Time) {
 								iruntime.Call2(runOpts.Hooks.StageExhausted, runCtx, StageExhaustedEvent[T]{
 									RunID:    runID,
 									Stage:    stage,
 									Input:    in,
 									Attempts: attempt,
 									Err:      err,
-									At:       attemptFinish,
+									At:       at,
 								})
-								iruntime.Call2(runOpts.Hooks.StageError, runCtx, StageErrorEvent[T]{
-									RunID:      runID,
-									Stage:      stage,
-									Input:      in,
-									StartedAt:  stageStart,
-									FinishedAt: attemptFinish,
-									Duration:   attemptFinish.Sub(stageStart),
-									Err:        err,
-								})
-								break
-							}
+							},
+						})
 
-							iruntime.Call2(runOpts.Hooks.StageRetry, runCtx, StageRetryEvent[T]{
-								RunID:   runID,
-								Stage:   stage,
-								Input:   in,
-								Attempt: attempt,
-								Err:     err,
-								Backoff: policy.Backoff,
-								At:      attemptFinish,
-							})
-
-							// context-aware backoff
-							if policy.Backoff > 0 {
-								select {
-								case <-runCtx.Done():
-									return runCtx.Err()
-								case <-time.After(policy.Backoff):
-								}
-							}
-						}
-
-						if err != nil {
-							if frontierEntryID != 0 {
+						if execResult.Err != nil {
+							err := execResult.Err
+							if execResult.AckOnError && frontierEntryID != 0 {
 								ackErr := fs.Ack(frontierEntryID)
 								if ackErr != nil {
 									return fmt.Errorf("stage %s: %w", stage, errors.Join(err, fmt.Errorf("frontier ack after stage error: %w", ackErr)))
@@ -441,8 +407,12 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 									At:      time.Now(),
 								})
 							}
+							if isContextErr(err) {
+								return err
+							}
 							return fmt.Errorf("stage %s: %w", stage, err)
 						}
+						out := execResult.Out
 
 						resultsMu.Lock()
 						results[stage] = append(results[stage], out...)


### PR DESCRIPTION
## Summary

This PR continues the runtime-internals extraction by moving two core Pipeline.Run execution paths into internal/runtime while preserving existing behavior and public
API.

## Commits

- 7d30bec Extract direct enqueue dispatch mechanics into internal runtime helper
- 364bdcb Extract stage execution retry loop into internal runtime helper

## What Changed

### 1) Direct enqueue mechanics extracted

- Added direct_enqueue.go:
  - DirectEnqueueConfig
  - EnqueueDirect(...)
- Updated pipeline.go:
  - enqueueDirect now delegates queue lookup/context gate/schedule/send behavior to runtime helper.
  - Stage job execution remains callback-driven from pipeline layer.

### 2) Stage execution loop extracted

- Added stage_execute.go:
  - StageExecutionPolicy
  - StageExecutionConfig
  - StageExecutionResult
  - ExecuteStageWithPolicy(...)
- Updated pipeline.go:
  - Stage retry/timeout/attempt loop now uses runtime helper.
  - Hook payloads, error wrapping, and frontier ack semantics are preserved via callbacks and result handling (AckOnError).

## Tests Added

- direct_enqueue_test.go
  - stage-not-found path
  - cancel-after-build cleanup path
  - successful enqueue path
- stage_execute_test.go
  - exhausted retries sets AckOnError=true
  - canceled context keeps AckOnError=false
  - retry-then-success flow

## Compatibility / Behavior

- No public API signature changes.
- Runtime behavior is intended to be unchanged; this is a structural refactor.
- pipeline.Run remains the orchestration facade with runtime helpers underneath.

## Validation

- go test ./... passed after changes.
- Recommended before merge:
  - go test -race ./...

