### PR TITLE
Session Runtime Durability and Status Observability Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Additional docs:
 - Product direction: `docs/product-plan.md`
 - Architecture boundaries: `docs/architecture.md`
 - Engine-scanner boundary: `docs/boundary.md`
+- Session runtime semantics: `docs/session-runtime.md`
 
 ## Examples
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,14 @@
-# Pipex Architecture Boundaries and Extraction Plan
+# Pipex Architecture Boundaries and Runtime Map
 
 ## Purpose
 
 This document defines:
 
 1. Ownership boundaries for `internal/graph` and `internal/runtime`.
-2. Criteria for when code should move from root package files into `internal/`.
-3. The first migration slice to start using `internal/` without changing public API.
+2. Current runtime decomposition (`Pipeline.Run` facade -> runtime helpers).
+3. Rules for future extractions without API behavior changes.
 
-The current implementation remains rooted in `pipeline.go` and `compose.go`. The goal is to extract cohesive internals incrementally while preserving behavior.
+`Pipeline.Run` remains the public orchestration entrypoint. Internal execution details are progressively delegated to `internal/runtime`.
 
 ## 1) Ownership Boundaries
 
@@ -17,30 +17,27 @@ The current implementation remains rooted in `pipeline.go` and `compose.go`. The
 Scope:
 
 - Graph validation rules (stage existence checks, edge validity).
-- DAG cycle detection and future cycle-mode helpers.
-- Traversal helpers that are pure graph concerns (topological/frontier utilities).
-- Future dedup/frontier graph metadata (if graph-structural, not runtime-stateful).
+- DAG cycle detection and related graph utilities.
+- Pure graph traversal helpers.
 
 Non-scope:
 
 - Worker pools, goroutine lifecycle, context cancellation handling.
 - Trigger/sink execution logic.
-- Item processing orchestration.
+- Runtime scheduling and queue coordination.
 
 Design rule:
 
 - Keep `internal/graph` deterministic and side-effect light.
-- Prefer pure functions and immutable snapshots as inputs.
 
 ### `internal/runtime`
 
 Scope:
 
-- Pipeline run orchestration and lifecycle coordination.
-- Enqueue/drain mechanics, stage worker orchestration, waitgroup ordering.
-- Trigger and sink coordination across run lifecycle.
-- Error aggregation and cancellation policy application.
-- Future runtime policies (stage retry/timeout, rate limit enforcement hooks).
+- Pipeline run orchestration helpers and lifecycle coordination.
+- Frontier scheduler, enqueue, and gate logic.
+- Stage execution policy loops (attempt/retry/timeout behavior).
+- Concurrency helpers around queueing/scheduling.
 
 Non-scope:
 
@@ -49,64 +46,61 @@ Non-scope:
 
 Design rule:
 
-- `internal/runtime` owns concurrency semantics; external packages should not reimplement them.
-- Runtime should execute against stable stage metadata captured at run start (for example, worker count), not mutable values that may drift mid-lifecycle.
+- `internal/runtime` owns reusable execution mechanics.
+- Root package (`pipex`) remains the policy facade that maps runtime hooks/errors to public contracts.
 
-## 2) Extraction Criteria
+## 2) Current Runtime Map
 
-Move code from root into `internal/` only when all conditions hold:
+`Pipeline.Run` currently delegates these responsibilities:
+
+- `validateRunPreflight(...)`: run-time input/option preflight checks.
+- `buildDedupRulesByStage(...)`: dedup rules validation and expansion.
+- `buildStageLimiters(...)`: per-stage rate limiter setup.
+- `createPoolsByStage(...)`: pool creation and worker snapshot.
+- `startSinkWorkers(...)`: sink worker lifecycle.
+- `startStagePools(...)`: stage pool startup and error fan-in.
+- `enqueueSeeds(...)`: initial seed enqueue path.
+- `startTriggerWorkers(...)`: trigger lifecycle and emit path.
+- `waitForFrontierOutstanding(...)`: frontier drain/wait shutdown path.
+- `setupFrontierRuntime(...)`: frontier store/stats/requeue setup.
+
+`internal/runtime` currently provides:
+
+- `RunFrontierScheduler(...)` (`frontier_scheduler.go`): reserve/dispatch loop.
+- `EnqueueWithBackpressure(...)` (`frontier_enqueue.go`): non-blocking frontier backpressure retry.
+- `SafeStringKey(...)` (`dedup.go`): panic-safe dedup key evaluation.
+- `EvaluateCycleGate(...)` and `SeenContainsOrInsert(...)` (`gates.go`): cycle/dedup gate utilities.
+- `ExecuteGuardedEnqueue(...)` (`guarded_enqueue.go`): guarded enqueue orchestration.
+- `EnqueueDirect(...)` (`direct_enqueue.go`): direct queue enqueue mechanics.
+- `ExecuteStageWithPolicy(...)` (`stage_execute.go`): attempt/retry/timeout execution loop.
+
+## 3) Extraction Rules
+
+Move logic from `pipeline.go` to `internal/runtime` only when all conditions hold:
 
 1. Cohesion is clear.
-- The code cluster serves one concern (`graph` or `runtime`) without requiring broad cross-file context.
+- The extracted code serves one execution concern and has a narrow config surface.
 
 2. Public API stability is preserved.
-- No exported type/function signatures need to change.
-- Root package remains the stable facade (`Pipeline.Run`, `Validate`, composition helpers).
+- No exported signatures change.
+- `Pipeline.Run` remains the single public runtime entrypoint.
 
-3. Behavioral parity is provable.
-- Existing tests still express the same semantics.
-- No expected ordering/cancellation/error behavior changes in the migration commit.
+3. Behavioral parity is proven.
+- Existing integration tests stay green.
+- Add focused `internal/runtime` tests for each extracted helper.
 
-4. Complexity threshold is reached.
-- A function/file mixes multiple concerns (for example, validation + orchestration), making maintenance harder than delegation.
+4. Dependency direction stays clean.
+- Root package may depend on `internal/runtime`.
+- `internal/runtime` must not import root package types.
 
-5. Dependency direction remains clean.
-- Root package may delegate to `internal/*`.
-- `internal/graph` must not depend on `internal/runtime`.
-- `internal/runtime` can depend on `internal/graph` only via narrow inputs if needed.
+5. Error/hook mapping remains in root package when domain-specific.
+- Runtime helpers should expose callback hooks/results.
+- Root package converts callbacks/results into public events/errors.
 
-6. Migration unit is independently reviewable.
-- A single extraction change should be understandable without requiring future planned refactors.
+## 4) Next Targets
 
-## 3) First Migration Slice
-
-### Target
-
-Extract graph validation logic from `pipeline.go` into `internal/graph` first.
-
-Recommended extraction scope:
-
-- Stage/edge existence checks currently in validation path.
-- DAG cycle detection currently in `validateSnapshot`.
-
-Keep in root package:
-
-- Public method entry points (`Validate`, `Run` preflight checks).
-- Error construction and public error types in `errors.go`.
-
-### Why this first
-
-- Lowest risk: graph validation is relatively pure and easier to isolate.
-- High clarity gain: reduces mixed responsibilities in `pipeline.go`.
-- No runtime-concurrency behavior impact.
-
-### Migration shape
-
-1. Introduce internal graph validator API that accepts stage/edge snapshots.
-2. Delegate `validateSnapshot` internals to `internal/graph`.
-3. Keep outward error behavior unchanged (`ErrNoStages`, `ErrCycle`, `StageNotFound` wrapping semantics).
-4. Keep all existing tests green with no behavioral edits.
-
-### Deferred until later
-
-Do not extract runtime orchestration yet (`Run` goroutine choreography, sink/trigger lifecycle), because hooks/retry policy design may still evolve and would cause churn.
+- Continue reducing closure-heavy wiring in `Pipeline.Run` by grouping helper configs into smaller typed bundles.
+- Keep extraction slices small and independently reviewable.
+- Maintain parity checks with:
+  - `go test ./...`
+  - `go test -race ./...`

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -1,0 +1,89 @@
+# Session Runtime (Engine-Level)
+
+## Purpose
+
+Define resumable runtime semantics for `pipex` without introducing scanner-specific domain concepts.
+
+This document describes execution session primitives only. Scanner domain semantics (`scope`, `target`, `finding`, UX) remain owned by `penta`.
+
+## Boundary
+
+- `pipex` owns execution identity, queue/runtime state, and resume behavior.
+- `penta` owns scanner domain models and user-facing session workflow.
+
+## Identity Model
+
+- `run_id`: unique execution identifier (already present in runtime hooks/metadata).
+- `runtime_namespace` (optional): logical partition key for durable frontier storage to isolate concurrent execution domains.
+- `entry_key`: durable/idempotent unit key for frontier entries (store-level concern).
+
+`pipex` should not define scanner IDs; mapping from scanner session IDs to runtime identity is application-owned.
+
+## Execution States
+
+Runtime state model for resumable execution:
+
+- `pending`: accepted and queued for processing.
+- `reserved`: leased to a worker/scheduler path.
+- `retried`: requeued after failure.
+- `acked`: completed terminal success.
+- `terminal_failed`: completed terminal failure (non-retriable/exhausted).
+- `dropped`: intentionally skipped by runtime rule (for example dedup/hop guard).
+- `canceled`: canceled by context/session stop.
+
+## Lifecycle Semantics
+
+1. Start
+- New run starts with `run_id`.
+- Seeds/triggers enqueue to frontier/direct runtime as configured.
+
+2. Pause (engine semantic)
+- Stop accepting new dispatch from scheduler.
+- Keep durable runtime state intact (`pending`/`reserved` entries preserved for resume).
+- Inflight items are allowed to settle to terminal/ retryable state according to policy.
+
+3. Resume
+- Rehydrate scheduler from durable frontier state.
+- Requeue expired/abandoned `reserved` leases according to lease policy.
+- Continue dispatch from `pending` and requeued entries.
+
+4. Cancel
+- Stop scheduling and mark run canceled from runtime perspective.
+- Outstanding entries transition per policy (`canceled` or retained for later resume if cancellation policy allows).
+
+## Failure and Idempotency Rules
+
+- Requeue of expired reservations must be idempotent.
+- Ack/retry operations must be monotonic by entry state (invalid transitions are explicit errors).
+- Resume should be safe to call repeatedly (no duplicate terminal transitions).
+- Entry key uniqueness should prevent duplicate durable entry creation where supported by store.
+
+## Minimal Internal API Proposal (No Public Break Yet)
+
+Initial internal-facing shape (illustrative):
+
+- `runtime.StartRun(ctx, cfg) -> runRef`
+- `runtime.PauseRun(ctx, runRef) error`
+- `runtime.ResumeRun(ctx, runRef) error`
+- `runtime.CancelRun(ctx, runRef) error`
+- `runtime.RunStatus(ctx, runRef) -> status`
+
+Where:
+
+- `runRef` contains engine identity (`run_id`, optional namespace/store refs).
+- `status` reports aggregate runtime counters by state, not scanner domain objects.
+
+These can remain internal until semantics stabilize.
+
+## Out of Scope (For This Doc)
+
+- Scanner-specific workflow state machine.
+- TUI interaction flows.
+- Findings/result storage schema.
+- Public API commitment for pause/resume until internal behavior hardens.
+
+## Next Implementation Slice
+
+- Define durable lease-expiry requeue policy constants and tests.
+- Add internal run status snapshot aggregation for durable frontier stores.
+- Validate resume idempotency under repeated calls and partial failures.

--- a/internal/frontier/durable.go
+++ b/internal/frontier/durable.go
@@ -11,6 +11,16 @@ type Lease struct {
 	Until time.Time
 }
 
+const (
+	// DefaultDurableLeaseTTL is the default reservation lease window used by
+	// durable frontier implementations when no explicit policy override exists.
+	DefaultDurableLeaseTTL = 30 * time.Second
+
+	// DefaultRequeueExpiredLimit bounds how many expired reservations are
+	// requeued in one recovery pass.
+	DefaultRequeueExpiredLimit = 4096
+)
+
 type DurableFrontierStore[T any] interface {
 	Enqueue(ctx context.Context, e Entry[T]) (created bool, err error) // idempotent by Key
 	Reserve(ctx context.Context, max int, leaseTTL time.Duration) ([]Entry[T], []Lease, error)

--- a/internal/frontier/durable.go
+++ b/internal/frontier/durable.go
@@ -29,3 +29,20 @@ type DurableFrontierStore[T any] interface {
 	MarkTerminalFailed(ctx context.Context, key, leaseID string, cause error) error
 	RequeueExpired(ctx context.Context, now time.Time, limit int) (int, error)
 }
+
+type DurableStatusSnapshot struct {
+	Pending        int64
+	Reserved       int64
+	Acked          int64
+	TerminalFailed int64
+	Dropped        int64
+	Canceled       int64
+	// Optional/derived:
+	RetriedEntries int64 // attempt > 1
+	Total          int64
+	At             time.Time
+}
+
+type DurableStatusProvider interface {
+	StatusSnapshot(ctx context.Context) (DurableStatusSnapshot, error)
+}

--- a/internal/frontier/frontier.go
+++ b/internal/frontier/frontier.go
@@ -3,7 +3,7 @@ package frontier
 import "context"
 
 type Entry[T any] struct {
-	Key		 string
+	Key     string
 	ID      uint64
 	Stage   string
 	Input   T

--- a/internal/frontier/sqlite/store.go
+++ b/internal/frontier/sqlite/store.go
@@ -357,3 +357,31 @@ func (s *DurableStore[T]) RequeueExpired(ctx context.Context, now time.Time, lim
 	}
 	return updated, nil
 }
+
+func (s *DurableStore[T]) StatusSnapshot(ctx context.Context) (frontier.DurableStatusSnapshot, error) {
+	if err := s.ensureSchema(); err != nil {
+		return frontier.DurableStatusSnapshot{}, err
+	}
+
+	row := s.db.QueryRowContext(ctx, `
+	SELECT
+		COALESCE(SUM(CASE WHEN state = 'pending' THEN 1 ELSE 0 END), 0) AS pending,
+		COALESCE(SUM(CASE WHEN state = 'reserved' THEN 1 ELSE 0 END), 0) AS reserved,
+		COALESCE(SUM(CASE WHEN state = 'acked' THEN 1 ELSE 0 END), 0) AS acked,
+		COALESCE(SUM(CASE WHEN state = 'terminal_failed' THEN 1 ELSE 0 END), 0) AS terminal_failed,
+		COALESCE(SUM(CASE WHEN state = 'dropped' THEN 1 ELSE 0 END), 0) AS dropped,
+		COALESCE(SUM(CASE WHEN state = 'canceled' THEN 1 ELSE 0 END), 0) AS canceled,
+		COALESCE(SUM(CASE WHEN attempt > 1 THEN 1 ELSE 0 END), 0) AS retried_entries,
+		COUNT(*) AS total
+	FROM frontier;
+	`)
+	var snap frontier.DurableStatusSnapshot
+	if err := row.Scan(
+		&snap.Pending, &snap.Reserved, &snap.Acked, &snap.TerminalFailed,
+		&snap.Dropped, &snap.Canceled, &snap.RetriedEntries, &snap.Total,
+	); err != nil {
+		return frontier.DurableStatusSnapshot{}, fmt.Errorf("%w: %w", ErrDatabase, err)
+	}
+	snap.At = s.now()
+	return snap, nil
+}

--- a/internal/frontier/sqlite/store_test.go
+++ b/internal/frontier/sqlite/store_test.go
@@ -161,3 +161,113 @@ func TestDurableStoreRequeueExpiredHonorsLimit(t *testing.T) {
 		t.Fatalf("expected second requeue count 1, got %d", n)
 	}
 }
+
+func TestDurableStoreRequeueExpired_IdempotentWithoutNewReserve(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.UnixMilli(1_700_000_200_000)
+	s.now = func() time.Time { return base }
+
+	_, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-idem", Stage: "a", Input: 1, Hops: 0, Attempt: 1,
+	})
+	if err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+	_, _, err = s.Reserve(ctx, 1, 5*time.Second)
+	if err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+
+	afterExpiry := base.Add(10 * time.Second)
+	n, err := s.RequeueExpired(ctx, afterExpiry, 10)
+	if err != nil {
+		t.Fatalf("first requeue failed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected first requeue count 1, got %d", n)
+	}
+
+	n, err = s.RequeueExpired(ctx, afterExpiry, 10)
+	if err != nil {
+		t.Fatalf("second requeue failed: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected second requeue count 0, got %d", n)
+	}
+}
+
+func TestDurableStoreRequeueExpired_OncePerLeaseCycle(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.UnixMilli(1_700_000_300_000)
+	s.now = func() time.Time { return base }
+
+	_, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-cycle", Stage: "a", Input: 1, Hops: 0, Attempt: 1,
+	})
+	if err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+	_, _, err = s.Reserve(ctx, 1, 5*time.Second)
+	if err != nil {
+		t.Fatalf("first reserve failed: %v", err)
+	}
+
+	firstExpiry := base.Add(10 * time.Second)
+	n, err := s.RequeueExpired(ctx, firstExpiry, 10)
+	if err != nil {
+		t.Fatalf("first requeue failed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected first requeue count 1, got %d", n)
+	}
+
+	// Reserve again to create a new lease cycle for the same entry.
+	s.now = func() time.Time { return firstExpiry.Add(time.Millisecond) }
+	entries, leases, err := s.Reserve(ctx, 1, 5*time.Second)
+	if err != nil {
+		t.Fatalf("second reserve failed: %v", err)
+	}
+	if len(entries) != 1 || len(leases) != 1 {
+		t.Fatalf("expected one entry in second reserve, got entries=%d leases=%d", len(entries), len(leases))
+	}
+
+	secondExpiry := firstExpiry.Add(10 * time.Second)
+	n, err = s.RequeueExpired(ctx, secondExpiry, 10)
+	if err != nil {
+		t.Fatalf("second cycle requeue failed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected second cycle requeue count 1, got %d", n)
+	}
+}
+
+func TestDurableStoreRequeueExpired_NoopBeforeLeaseExpiry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.UnixMilli(1_700_000_400_000)
+	s.now = func() time.Time { return base }
+
+	_, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-not-expired", Stage: "a", Input: 1, Hops: 0, Attempt: 1,
+	})
+	if err != nil {
+		t.Fatalf("enqueue failed: %v", err)
+	}
+	_, _, err = s.Reserve(ctx, 1, 30*time.Second)
+	if err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+
+	n, err := s.RequeueExpired(ctx, base.Add(5*time.Second), 10)
+	if err != nil {
+		t.Fatalf("requeue before expiry failed: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected requeue count 0 before lease expiry, got %d", n)
+	}
+}

--- a/internal/frontier/sqlite/store_test.go
+++ b/internal/frontier/sqlite/store_test.go
@@ -271,3 +271,130 @@ func TestDurableStoreRequeueExpired_NoopBeforeLeaseExpiry(t *testing.T) {
 		t.Fatalf("expected requeue count 0 before lease expiry, got %d", n)
 	}
 }
+
+func TestDurableStoreStatusSnapshot_Empty(t *testing.T) {
+	s := newTestStore(t)
+
+	base := time.UnixMilli(1_700_000_500_000)
+	s.now = func() time.Time { return base }
+
+	snap, err := s.StatusSnapshot(context.Background())
+	if err != nil {
+		t.Fatalf("status snapshot failed: %v", err)
+	}
+	if snap.Pending != 0 || snap.Reserved != 0 || snap.Acked != 0 || snap.TerminalFailed != 0 ||
+		snap.Dropped != 0 || snap.Canceled != 0 || snap.RetriedEntries != 0 || snap.Total != 0 {
+		t.Fatalf("unexpected non-zero snapshot: %+v", snap)
+	}
+	if !snap.At.Equal(base) {
+		t.Fatalf("unexpected snapshot time: got=%v want=%v", snap.At, base)
+	}
+}
+
+func TestDurableStoreStatusSnapshot_MixedStatesAndRetried(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.UnixMilli(1_700_000_600_000)
+	s.now = func() time.Time { return base }
+
+	// pending (attempt=1)
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-pending", Stage: "a", Input: 1, Hops: 0, Attempt: 1,
+	}); err != nil {
+		t.Fatalf("enqueue pending failed: %v", err)
+	}
+
+	// pending retried (attempt=2)
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-retried", Stage: "a", Input: 2, Hops: 0, Attempt: 2,
+	}); err != nil {
+		t.Fatalf("enqueue retried failed: %v", err)
+	}
+
+	// reserved -> acked
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-acked", Stage: "a", Input: 3, Hops: 0, Attempt: 1,
+	}); err != nil {
+		t.Fatalf("enqueue acked failed: %v", err)
+	}
+	entries, leases, err := s.Reserve(ctx, 1, 10*time.Second)
+	if err != nil || len(entries) != 1 || len(leases) != 1 {
+		t.Fatalf("reserve for acked failed entries=%d leases=%d err=%v", len(entries), len(leases), err)
+	}
+	if entries[0].Key != "k-acked" {
+		t.Fatalf("unexpected reserved key for acked flow: %s", entries[0].Key)
+	}
+	if err := s.Ack(ctx, entries[0].Key, leases[0].ID); err != nil {
+		t.Fatalf("ack failed: %v", err)
+	}
+
+	// reserved -> terminal_failed
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-failed", Stage: "a", Input: 4, Hops: 0, Attempt: 1,
+	}); err != nil {
+		t.Fatalf("enqueue failed-flow failed: %v", err)
+	}
+	entries, leases, err = s.Reserve(ctx, 1, 10*time.Second)
+	if err != nil || len(entries) != 1 || len(leases) != 1 {
+		t.Fatalf("reserve for failed flow failed entries=%d leases=%d err=%v", len(entries), len(leases), err)
+	}
+	if entries[0].Key != "k-failed" {
+		t.Fatalf("unexpected reserved key for failed flow: %s", entries[0].Key)
+	}
+	if err := s.MarkTerminalFailed(ctx, entries[0].Key, leases[0].ID, errors.New("boom")); err != nil {
+		t.Fatalf("mark terminal failed failed: %v", err)
+	}
+
+	// direct state setup for dropped/canceled coverage
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-dropped", Stage: "a", Input: 5, Hops: 0, Attempt: 1,
+	}); err != nil {
+		t.Fatalf("enqueue dropped failed: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE frontier SET state='dropped' WHERE key='k-dropped';`); err != nil {
+		t.Fatalf("set dropped failed: %v", err)
+	}
+
+	if _, err := s.Enqueue(ctx, frontier.Entry[int]{
+		Key: "k-canceled", Stage: "a", Input: 6, Hops: 0, Attempt: 1,
+	}); err != nil {
+		t.Fatalf("enqueue canceled failed: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE frontier SET state='canceled' WHERE key='k-canceled';`); err != nil {
+		t.Fatalf("set canceled failed: %v", err)
+	}
+
+	snap, err := s.StatusSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("status snapshot failed: %v", err)
+	}
+
+	if snap.Pending != 2 {
+		t.Fatalf("pending=%d want=2", snap.Pending)
+	}
+	if snap.Reserved != 0 {
+		t.Fatalf("reserved=%d want=0", snap.Reserved)
+	}
+	if snap.Acked != 1 {
+		t.Fatalf("acked=%d want=1", snap.Acked)
+	}
+	if snap.TerminalFailed != 1 {
+		t.Fatalf("terminal_failed=%d want=1", snap.TerminalFailed)
+	}
+	if snap.Dropped != 1 {
+		t.Fatalf("dropped=%d want=1", snap.Dropped)
+	}
+	if snap.Canceled != 1 {
+		t.Fatalf("canceled=%d want=1", snap.Canceled)
+	}
+	if snap.RetriedEntries != 1 {
+		t.Fatalf("retried_entries=%d want=1", snap.RetriedEntries)
+	}
+	if snap.Total != 6 {
+		t.Fatalf("total=%d want=6", snap.Total)
+	}
+	if !snap.At.Equal(base) {
+		t.Fatalf("unexpected snapshot time: got=%v want=%v", snap.At, base)
+	}
+}

--- a/internal/runtime/frontier_scheduler_test.go
+++ b/internal/runtime/frontier_scheduler_test.go
@@ -98,9 +98,9 @@ type reserveStore[T any] struct {
 }
 
 func (s *reserveStore[T]) Enqueue(stage string, item T, hops int) (uint64, error) { return 0, nil }
-func (s *reserveStore[T]) Ack(id uint64) error                                     { return nil }
-func (s *reserveStore[T]) Retry(id uint64, cause error) error                      { return nil }
-func (s *reserveStore[T]) Close() error                                            { return nil }
+func (s *reserveStore[T]) Ack(id uint64) error                                    { return nil }
+func (s *reserveStore[T]) Retry(id uint64, cause error) error                     { return nil }
+func (s *reserveStore[T]) Close() error                                           { return nil }
 func (s *reserveStore[T]) Reserve(ctx context.Context) (frontier.Entry[T], bool, error) {
 	if s.idx >= len(s.reserves) {
 		return frontier.Entry[T]{}, false, nil
@@ -122,9 +122,9 @@ type batchReserveStore[T any] struct {
 }
 
 func (s *batchReserveStore[T]) Enqueue(stage string, item T, hops int) (uint64, error) { return 0, nil }
-func (s *batchReserveStore[T]) Ack(id uint64) error                                     { return nil }
-func (s *batchReserveStore[T]) Retry(id uint64, cause error) error                      { return nil }
-func (s *batchReserveStore[T]) Close() error                                            { return nil }
+func (s *batchReserveStore[T]) Ack(id uint64) error                                    { return nil }
+func (s *batchReserveStore[T]) Retry(id uint64, cause error) error                     { return nil }
+func (s *batchReserveStore[T]) Close() error                                           { return nil }
 func (s *batchReserveStore[T]) Reserve(ctx context.Context) (frontier.Entry[T], bool, error) {
 	return frontier.Entry[T]{}, false, nil
 }

--- a/internal/runtime/status.go
+++ b/internal/runtime/status.go
@@ -1,0 +1,37 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/ruohao1/pipex/internal/frontier"
+)
+
+// TryDurableStatusSnapshot fetches a durable status snapshot when the store
+// implements frontier.DurableStatusProvider.
+func TryDurableStatusSnapshot(ctx context.Context, store any) (frontier.DurableStatusSnapshot, bool, error) {
+	provider, ok := store.(frontier.DurableStatusProvider)
+	if !ok {
+		return frontier.DurableStatusSnapshot{}, false, nil
+	}
+	snap, err := provider.StatusSnapshot(ctx)
+	if err != nil {
+		return frontier.DurableStatusSnapshot{}, true, err
+	}
+	return snap, true, nil
+}
+
+func DurableSnapshotToStats(s frontier.DurableStatusSnapshot) frontier.Stats {
+	return frontier.Stats{
+		Pending:        s.Pending,
+		Inflight:       s.Reserved,
+		Acked:          s.Acked,
+		Retried:        s.RetriedEntries,
+		Dropped:        s.Dropped,
+		TerminalFailed: s.TerminalFailed,
+		Canceled:       s.Canceled,
+		// Durable snapshots currently do not carry queue depth / enqueue-full
+		// counters in a portable way.
+		PendingQueueDepth: 0,
+		EnqueueFull:       0,
+	}
+}

--- a/internal/runtime/status_test.go
+++ b/internal/runtime/status_test.go
@@ -1,0 +1,79 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ruohao1/pipex/internal/frontier"
+)
+
+func TestTryDurableStatusSnapshot_Present(t *testing.T) {
+	store := durableStatusStore{
+		snapshot: frontier.DurableStatusSnapshot{
+			Pending: 1, Reserved: 2, Acked: 3, RetriedEntries: 4,
+		},
+	}
+	snap, ok, err := TryDurableStatusSnapshot(context.Background(), store)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected provider detection")
+	}
+	if snap.Pending != 1 || snap.Reserved != 2 || snap.Acked != 3 || snap.RetriedEntries != 4 {
+		t.Fatalf("unexpected snapshot: %+v", snap)
+	}
+}
+
+func TestTryDurableStatusSnapshot_Absent(t *testing.T) {
+	type noProvider struct{}
+	_, ok, err := TryDurableStatusSnapshot(context.Background(), noProvider{})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no provider")
+	}
+}
+
+func TestTryDurableStatusSnapshot_Error(t *testing.T) {
+	want := errors.New("boom")
+	store := durableStatusStore{err: want}
+	_, ok, err := TryDurableStatusSnapshot(context.Background(), store)
+	if !ok {
+		t.Fatal("expected provider detection")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("err=%v want=%v", err, want)
+	}
+}
+
+func TestDurableSnapshotToStats(t *testing.T) {
+	in := frontier.DurableStatusSnapshot{
+		Pending:        10,
+		Reserved:       3,
+		Acked:          8,
+		RetriedEntries: 2,
+		Dropped:        1,
+		TerminalFailed: 4,
+		Canceled:       5,
+	}
+	out := DurableSnapshotToStats(in)
+	if out.Pending != 10 || out.Inflight != 3 || out.Acked != 8 || out.Retried != 2 ||
+		out.Dropped != 1 || out.TerminalFailed != 4 || out.Canceled != 5 {
+		t.Fatalf("unexpected stats conversion: %+v", out)
+	}
+}
+
+type durableStatusStore struct {
+	snapshot frontier.DurableStatusSnapshot
+	err      error
+}
+
+func (d durableStatusStore) StatusSnapshot(ctx context.Context) (frontier.DurableStatusSnapshot, error) {
+	if d.err != nil {
+		return frontier.DurableStatusSnapshot{}, d.err
+	}
+	return d.snapshot, nil
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -1027,8 +1027,7 @@ func setupFrontierRuntime[T any](
 	}
 
 	if dfs, ok := fs.(frontier.DurableFrontierStore[T]); ok {
-		const requeueLimit = 4096 // or run option
-		if n, err := dfs.RequeueExpired(runCtx, time.Now(), requeueLimit); err != nil {
+		if n, err := dfs.RequeueExpired(runCtx, time.Now(), frontier.DefaultRequeueExpiredLimit); err != nil {
 			recordErr(fmt.Errorf("frontier requeue expired: %w", err))
 			if runOpts.FailFast {
 				return nil, closeOnExit, err

--- a/pipeline.go
+++ b/pipeline.go
@@ -1075,6 +1075,44 @@ func setupFrontierRuntime[T any](
 					}
 				}
 			})
+		} else if _, ok, _ := iruntime.TryDurableStatusSnapshot(runCtx, fs); ok {
+			statsCtx, statsCancel := context.WithCancel(runCtx)
+			*stopFrontierStats = statsCancel
+			frontierStatsWG.Go(func() {
+				emit := func() {
+					snap, _, err := iruntime.TryDurableStatusSnapshot(runCtx, fs)
+					if err != nil {
+						recordErr(fmt.Errorf("frontier durable status snapshot: %w", err))
+						return
+					}
+					stats := iruntime.DurableSnapshotToStats(snap)
+					iruntime.Call2(runOpts.Hooks.FrontierStats, runCtx, FrontierStatsEvent{
+						RunID:             runID,
+						Pending:           stats.Pending,
+						Inflight:          stats.Inflight,
+						Acked:             stats.Acked,
+						Retried:           stats.Retried,
+						Dropped:           stats.Dropped,
+						TerminalFailed:    stats.TerminalFailed,
+						Canceled:          stats.Canceled,
+						EnqueueFull:       stats.EnqueueFull,
+						PendingQueueDepth: stats.PendingQueueDepth,
+						At:                time.Now(),
+					})
+				}
+
+				emit()
+				ticker := time.NewTicker(runOpts.FrontierStatsInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-statsCtx.Done():
+						return
+					case <-ticker.C:
+						emit()
+					}
+				}
+			})
 		}
 	}
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/ruohao1/pipex/internal/frontier"
 )
 
 type testStage[T any] struct {
@@ -1939,4 +1941,157 @@ func TestRunFrontierStatsHookSampled(t *testing.T) {
 	if samples.Load() == 0 {
 		t.Fatal("expected at least one frontier stats sample")
 	}
+}
+
+func TestRunFrontierStatsHook_DurableProviderPresentEmits(t *testing.T) {
+	p := NewPipeline[int]()
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			time.Sleep(2 * time.Millisecond)
+			return []int{in}, nil
+		},
+	})
+
+	store := &durableStatusTestStore{
+		base: frontier.NewMemoryStoreWithCapacity[int](64),
+		snapshot: frontier.DurableStatusSnapshot{
+			Pending: 11, Reserved: 3, Acked: 7, RetriedEntries: 2, TerminalFailed: 1,
+		},
+	}
+
+	var (
+		samples  atomic.Int64
+		lastSeen atomic.Int64
+	)
+	_, err := p.Run(
+		context.Background(),
+		map[string][]int{"a": {1, 2}},
+		WithFrontier[int](true),
+		WithFrontierStore[int](store),
+		WithFrontierStatsInterval[int](1*time.Millisecond),
+		WithHooks[int](Hooks[int]{
+			FrontierStats: func(ctx context.Context, e FrontierStatsEvent) {
+				samples.Add(1)
+				lastSeen.Store(e.Pending)
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+	if samples.Load() == 0 {
+		t.Fatal("expected at least one frontier stats sample")
+	}
+	if lastSeen.Load() != 11 {
+		t.Fatalf("expected durable pending mapped to hook, got %d", lastSeen.Load())
+	}
+}
+
+func TestRunFrontierStatsHook_DurableProviderAbsentNoop(t *testing.T) {
+	p := NewPipeline[int]()
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			time.Sleep(2 * time.Millisecond)
+			return []int{in}, nil
+		},
+	})
+
+	store := &plainStoreNoStatsProvider{
+		base: frontier.NewMemoryStoreWithCapacity[int](64),
+	}
+
+	var samples atomic.Int64
+	_, err := p.Run(
+		context.Background(),
+		map[string][]int{"a": {1}},
+		WithFrontier[int](true),
+		WithFrontierStore[int](store),
+		WithFrontierStatsInterval[int](1*time.Millisecond),
+		WithHooks[int](Hooks[int]{
+			FrontierStats: func(ctx context.Context, e FrontierStatsEvent) {
+				samples.Add(1)
+			},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected run error: %v", err)
+	}
+	if samples.Load() != 0 {
+		t.Fatalf("expected no stats samples without providers, got %d", samples.Load())
+	}
+}
+
+func TestRunFrontierStatsHook_DurableProviderErrorRecorded(t *testing.T) {
+	p := NewPipeline[int]()
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			time.Sleep(2 * time.Millisecond)
+			return []int{in}, nil
+		},
+	})
+
+	store := &durableStatusTestStore{
+		base: frontier.NewMemoryStoreWithCapacity[int](64),
+		err:  errors.New("snapshot failed"),
+	}
+
+	_, err := p.Run(
+		context.Background(),
+		map[string][]int{"a": {1}},
+		WithFrontier[int](true),
+		WithFrontierStore[int](store),
+		WithFrontierStatsInterval[int](1*time.Millisecond),
+	)
+	if err == nil {
+		t.Fatal("expected run error from durable status provider failure")
+	}
+	if !strings.Contains(err.Error(), "frontier durable status snapshot") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type plainStoreNoStatsProvider struct {
+	base frontier.Store[int]
+}
+
+func (s *plainStoreNoStatsProvider) Enqueue(stage string, item int, hops int) (uint64, error) {
+	return s.base.Enqueue(stage, item, hops)
+}
+func (s *plainStoreNoStatsProvider) Reserve(ctx context.Context) (frontier.Entry[int], bool, error) {
+	return s.base.Reserve(ctx)
+}
+func (s *plainStoreNoStatsProvider) Ack(id uint64) error { return s.base.Ack(id) }
+func (s *plainStoreNoStatsProvider) Retry(id uint64, cause error) error {
+	return s.base.Retry(id, cause)
+}
+func (s *plainStoreNoStatsProvider) Close() error { return s.base.Close() }
+
+type durableStatusTestStore struct {
+	base     frontier.Store[int]
+	snapshot frontier.DurableStatusSnapshot
+	err      error
+}
+
+func (s *durableStatusTestStore) Enqueue(stage string, item int, hops int) (uint64, error) {
+	return s.base.Enqueue(stage, item, hops)
+}
+func (s *durableStatusTestStore) Reserve(ctx context.Context) (frontier.Entry[int], bool, error) {
+	return s.base.Reserve(ctx)
+}
+func (s *durableStatusTestStore) Ack(id uint64) error { return s.base.Ack(id) }
+func (s *durableStatusTestStore) Retry(id uint64, cause error) error {
+	return s.base.Retry(id, cause)
+}
+func (s *durableStatusTestStore) Close() error { return s.base.Close() }
+func (s *durableStatusTestStore) StatusSnapshot(ctx context.Context) (frontier.DurableStatusSnapshot, error) {
+	if s.err != nil {
+		return frontier.DurableStatusSnapshot{}, s.err
+	}
+	return s.snapshot, nil
 }

--- a/stage.go
+++ b/stage.go
@@ -9,11 +9,10 @@ type Stage[T any] interface {
 	Workers() int
 
 	// Process processes one input item and emits zero or more output items.
-  //
-  // Routing is handled by the pipeline graph (Connect edges), not by the stage.
-  // Each emitted item is forwarded to all configured downstream stages.
-  // Returning an error marks this item as failed and lets the pipeline apply
-  // its configured error policy (for example, fail-fast or continue).
+	//
+	// Routing is handled by the pipeline graph (Connect edges), not by the stage.
+	// Each emitted item is forwarded to all configured downstream stages.
+	// Returning an error marks this item as failed and lets the pipeline apply
+	// its configured error policy (for example, fail-fast or continue).
 	Process(ctx context.Context, in T) (outs []T, err error)
 }
-


### PR DESCRIPTION
## Summary

This PR strengthens engine-level session runtime foundations for durable execution and resume observability, without introducing scanner-specific semantics or public API
breaks.

## Commits

- 5158f18 Add durable requeue policy constants and use default requeue limit
- c02063d Add durable requeue-expired idempotency and lease-expiry tests
- 60aa58f Add durable status snapshot API and SQLite state-count implementation
- 6744e2d Emit frontier stats from durable status provider via runtime helper

## What Changed

### 1) Durable requeue policy constants

- Added explicit durable policy constants in internal/frontier/durable.go:
    - DefaultDurableLeaseTTL
    - DefaultRequeueExpiredLimit
- Replaced hardcoded requeue limit usage in runtime setup to use frontier.DefaultRequeueExpiredLimit.

### 2) Requeue-expired idempotency and lease-expiry tests

- Added focused SQLite durable frontier tests to validate:
    - repeated RequeueExpired(...) does not requeue the same reservation twice without a new lease cycle,
    - entries are requeued once per lease cycle,
    - non-expired leases are not requeued.

### 3) Durable status snapshot API + SQLite implementation

- Added DurableStatusSnapshot and DurableStatusProvider in internal/frontier/durable.go.
- Implemented StatusSnapshot(ctx) for SQLite durable store:
    - state counts (pending, reserved, acked, terminal_failed, dropped, canceled)
    - derived retried_entries (attempt > 1)
    - total, at
- SQL uses compatibility-safe aggregation:
    - COALESCE(SUM(CASE ...), 0)

### 4) Runtime helper + hook emission for durable status snapshots

- Added runtime helper in internal/runtime/status.go:
    - TryDurableStatusSnapshot(...)
    - DurableSnapshotToStats(...)
- Integrated into frontier stats emission path:
    - if frontier.StatsProvider is absent but DurableStatusProvider is present, sampled FrontierStats hook events are emitted from durable snapshot data.
    - snapshot fetch errors are routed through existing runtime error handling (recordErr) per current policy.

## Tests Added/Updated

- internal/frontier/sqlite/store_test.go:
    - requeue idempotency/lease-expiry tests
    - durable status snapshot tests (empty + mixed states)
- internal/runtime/status_test.go:
    - provider present / absent / error behavior
    - durable snapshot -> frontier stats conversion
- pipeline_test.go:
    - durable provider present => stats emitted
    - provider absent => no-op
    - provider error => surfaced through runtime error path

## Compatibility

- No public API signature changes.
- Engine/scanner boundary remains intact (pipex runtime semantics only).

## Validation

- go test ./... passes.
- Recommended pre-merge:
    - go test -race ./...
