### PR TITLE
Add Internal Session Runtime Controls and Durable Status Observability

### DIFF
--- a/internal/runtime/frontier_scheduler.go
+++ b/internal/runtime/frontier_scheduler.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ruohao1/pipex/internal/frontier"
 )
@@ -14,11 +15,18 @@ type FrontierSchedulerConfig[T any] struct {
 	IsContextErr func(error) bool
 	Dispatch     func(entry frontier.Entry[T])
 	OnError      func(error)
+	ShouldPause  func() bool
+	PausePoll    time.Duration
 }
 
 // RunFrontierScheduler reserves frontier entries and dispatches them until the
 // store closes, context ends, or a terminal reserve condition is reached.
 func RunFrontierScheduler[T any](cfg FrontierSchedulerConfig[T]) {
+	pausePoll := cfg.PausePoll
+	if pausePoll <= 0 {
+		pausePoll = 5 * time.Millisecond
+	}
+
 	batchSize := min(64, max(1, cfg.BufferSize))
 	batchBuf := make([]frontier.Entry[T], 0, batchSize)
 
@@ -28,6 +36,14 @@ func RunFrontierScheduler[T any](cfg FrontierSchedulerConfig[T]) {
 	batchReserver, hasBatchReserver := cfg.Store.(frontierBatchReserver)
 
 	for {
+		for cfg.ShouldPause != nil && cfg.ShouldPause() {
+			select {
+			case <-cfg.Ctx.Done():
+				return
+			case <-time.After(pausePoll):
+			}
+		}
+
 		if hasBatchReserver {
 			batchBuf = batchBuf[:0]
 			entries, ok, err := batchReserver.ReserveInto(cfg.Ctx, batchBuf, batchSize)

--- a/internal/runtime/run_handle.go
+++ b/internal/runtime/run_handle.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type RunState string
+
+const (
+	RunStateRunning   RunState = "running"
+	RunStatePaused    RunState = "paused"
+	RunStateCanceled  RunState = "canceled"
+	RunStateCompleted RunState = "completed"
+)
+
+type RunStatus struct {
+	RunID     string
+	State     RunState
+	UpdatedAt time.Time
+}
+
+// RunHandle is an internal control surface for run lifecycle state.
+// It is intentionally minimal and does not yet drive scheduler behavior.
+type RunHandle struct {
+	mu     sync.Mutex
+	runID  string
+	state  RunState
+	now    func() time.Time
+	cancel context.CancelFunc
+}
+
+func NewRunHandle(runID string, cancel context.CancelFunc) *RunHandle {
+	return &RunHandle{
+		runID:  runID,
+		state:  RunStateRunning,
+		now:    time.Now,
+		cancel: cancel,
+	}
+}
+
+// Pause transitions running -> paused. Returns true when state changed.
+func (h *RunHandle) Pause() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.state != RunStateRunning {
+		return false
+	}
+	h.state = RunStatePaused
+	return true
+}
+
+// Resume transitions paused -> running. Returns true when state changed.
+func (h *RunHandle) Resume() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.state != RunStatePaused {
+		return false
+	}
+	h.state = RunStateRunning
+	return true
+}
+
+// Cancel transitions any non-terminal state -> canceled and calls cancel once.
+// Returns true when state changed.
+func (h *RunHandle) Cancel() bool {
+	h.mu.Lock()
+	changed := h.state != RunStateCanceled && h.state != RunStateCompleted
+	if !changed {
+		h.mu.Unlock()
+		return false
+	}
+	h.state = RunStateCanceled
+	cancel := h.cancel
+	h.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	return true
+}
+
+// MarkCompleted transitions non-canceled state -> completed.
+// Returns true when state changed.
+func (h *RunHandle) MarkCompleted() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.state == RunStateCompleted || h.state == RunStateCanceled {
+		return false
+	}
+	h.state = RunStateCompleted
+	return true
+}
+
+func (h *RunHandle) Status() RunStatus {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return RunStatus{
+		RunID:     h.runID,
+		State:     h.state,
+		UpdatedAt: h.now(),
+	}
+}

--- a/internal/runtime/run_handle.go
+++ b/internal/runtime/run_handle.go
@@ -40,6 +40,12 @@ func NewRunHandle(runID string, cancel context.CancelFunc) *RunHandle {
 	}
 }
 
+func (h *RunHandle) SetCancel(cancel context.CancelFunc) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.cancel = cancel
+}
+
 // Pause transitions running -> paused. Returns true when state changed.
 func (h *RunHandle) Pause() bool {
 	h.mu.Lock()

--- a/internal/runtime/run_handle_test.go
+++ b/internal/runtime/run_handle_test.go
@@ -1,0 +1,77 @@
+package runtime
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunHandle_PauseResumeIdempotent(t *testing.T) {
+	h := NewRunHandle("r1", nil)
+
+	if !h.Pause() {
+		t.Fatal("expected first pause to change state")
+	}
+	if h.Pause() {
+		t.Fatal("expected second pause to be no-op")
+	}
+	if got := h.Status().State; got != RunStatePaused {
+		t.Fatalf("state=%s want=%s", got, RunStatePaused)
+	}
+
+	if !h.Resume() {
+		t.Fatal("expected resume from paused to change state")
+	}
+	if h.Resume() {
+		t.Fatal("expected second resume to be no-op")
+	}
+	if got := h.Status().State; got != RunStateRunning {
+		t.Fatalf("state=%s want=%s", got, RunStateRunning)
+	}
+}
+
+func TestRunHandle_CancelIdempotent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var cancelCalls atomic.Int64
+	h := NewRunHandle("r2", func() {
+		cancelCalls.Add(1)
+		cancel()
+	})
+
+	if !h.Cancel() {
+		t.Fatal("expected first cancel to change state")
+	}
+	if h.Cancel() {
+		t.Fatal("expected second cancel to be no-op")
+	}
+	if got := h.Status().State; got != RunStateCanceled {
+		t.Fatalf("state=%s want=%s", got, RunStateCanceled)
+	}
+	if cancelCalls.Load() != 1 {
+		t.Fatalf("cancel calls=%d want=1", cancelCalls.Load())
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("expected context cancellation")
+	}
+}
+
+func TestRunHandle_CompletedTerminal(t *testing.T) {
+	h := NewRunHandle("r3", nil)
+
+	if !h.MarkCompleted() {
+		t.Fatal("expected first completion to change state")
+	}
+	if h.MarkCompleted() {
+		t.Fatal("expected second completion to be no-op")
+	}
+	if h.Cancel() {
+		t.Fatal("expected cancel after completion to be no-op")
+	}
+	if got := h.Status().State; got != RunStateCompleted {
+		t.Fatalf("state=%s want=%s", got, RunStateCompleted)
+	}
+}

--- a/internal/runtime/run_registry.go
+++ b/internal/runtime/run_registry.go
@@ -1,0 +1,60 @@
+package runtime
+
+import "sync"
+
+var runHandleRegistry sync.Map // map[string]*RunHandle
+
+func RegisterRunHandle(runID string, h *RunHandle) {
+	if runID == "" || h == nil {
+		return
+	}
+	runHandleRegistry.Store(runID, h)
+}
+
+func UnregisterRunHandle(runID string) {
+	if runID == "" {
+		return
+	}
+	runHandleRegistry.Delete(runID)
+}
+
+func PauseRun(runID string) bool {
+	h, ok := lookupRunHandle(runID)
+	if !ok {
+		return false
+	}
+	return h.Pause()
+}
+
+func ResumeRun(runID string) bool {
+	h, ok := lookupRunHandle(runID)
+	if !ok {
+		return false
+	}
+	return h.Resume()
+}
+
+func CancelRun(runID string) bool {
+	h, ok := lookupRunHandle(runID)
+	if !ok {
+		return false
+	}
+	return h.Cancel()
+}
+
+func RunStatusByID(runID string) (RunStatus, bool) {
+	h, ok := lookupRunHandle(runID)
+	if !ok {
+		return RunStatus{}, false
+	}
+	return h.Status(), true
+}
+
+func lookupRunHandle(runID string) (*RunHandle, bool) {
+	v, ok := runHandleRegistry.Load(runID)
+	if !ok {
+		return nil, false
+	}
+	h, ok := v.(*RunHandle)
+	return h, ok
+}

--- a/internal/runtime/run_registry_test.go
+++ b/internal/runtime/run_registry_test.go
@@ -1,0 +1,46 @@
+package runtime
+
+import "testing"
+
+func TestRunRegistryPauseResumeAndStatus(t *testing.T) {
+	h := NewRunHandle("rid", nil)
+	RegisterRunHandle("rid", h)
+	defer UnregisterRunHandle("rid")
+
+	if !PauseRun("rid") {
+		t.Fatal("expected pause to succeed")
+	}
+	st, ok := RunStatusByID("rid")
+	if !ok {
+		t.Fatal("expected status to be available")
+	}
+	if st.State != RunStatePaused {
+		t.Fatalf("state=%s want=%s", st.State, RunStatePaused)
+	}
+
+	if !ResumeRun("rid") {
+		t.Fatal("expected resume to succeed")
+	}
+	st, ok = RunStatusByID("rid")
+	if !ok {
+		t.Fatal("expected status to be available")
+	}
+	if st.State != RunStateRunning {
+		t.Fatalf("state=%s want=%s", st.State, RunStateRunning)
+	}
+}
+
+func TestRunRegistryUnknownRunIDNoop(t *testing.T) {
+	if PauseRun("missing") {
+		t.Fatal("expected pause missing to be false")
+	}
+	if ResumeRun("missing") {
+		t.Fatal("expected resume missing to be false")
+	}
+	if CancelRun("missing") {
+		t.Fatal("expected cancel missing to be false")
+	}
+	if _, ok := RunStatusByID("missing"); ok {
+		t.Fatal("expected missing status to be absent")
+	}
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -46,6 +46,9 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 		opt(runOpts)
 	}
 	runID := iruntime.NewRunID()
+	runHandle := iruntime.NewRunHandle(runID, nil)
+	iruntime.RegisterRunHandle(runID, runHandle)
+	defer iruntime.UnregisterRunHandle(runID)
 
 	p.mu.RLock()
 	stages := make(map[string]Stage[T], len(p.stages))
@@ -128,7 +131,7 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	runCtx := ctx
-	runHandle := iruntime.NewRunHandle(runID, cancel)
+	runHandle.SetCancel(cancel)
 	defer func() {
 		if retErr == nil {
 			runHandle.MarkCompleted()
@@ -533,6 +536,10 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 			IsContextErr: isContextErr,
 			Dispatch:     dispatchReserved,
 			OnError:      recordErr,
+			ShouldPause: func() bool {
+				return runHandle.Status().State == iruntime.RunStatePaused
+			},
+			PausePoll: 5 * time.Millisecond,
 		})
 	})
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -128,6 +128,16 @@ func (p *Pipeline[T]) Run(ctx context.Context, seeds map[string][]T, opts ...Opt
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	runCtx := ctx
+	runHandle := iruntime.NewRunHandle(runID, cancel)
+	defer func() {
+		if retErr == nil {
+			runHandle.MarkCompleted()
+			return
+		}
+		// For now, non-success run exits are represented as canceled in the
+		// internal handle model until a dedicated failed terminal state exists.
+		runHandle.Cancel()
+	}()
 
 	isContextErr := func(err error) bool {
 		return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ruohao1/pipex/internal/frontier"
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
 )
 
 type testStage[T any] struct {
@@ -2053,6 +2054,70 @@ func TestRunFrontierStatsHook_DurableProviderErrorRecorded(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "frontier durable status snapshot") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
+	p := NewPipeline[int]()
+	var processed atomic.Int64
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			processed.Add(1)
+			return []int{in}, nil
+		},
+	})
+
+	done := make(chan error, 1)
+	var rid atomic.Value
+	go func() {
+		_, err := p.Run(
+			context.Background(),
+			map[string][]int{"a": {1, 2, 3, 4, 5}},
+			WithFrontier[int](true),
+			WithHooks[int](Hooks[int]{
+				RunStart: func(ctx context.Context, meta RunMeta) {
+					rid.Store(meta.RunID)
+					_ = iruntime.PauseRun(meta.RunID)
+				},
+			}),
+		)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for rid.Load() == nil && time.Now().Before(deadline) {
+		time.Sleep(1 * time.Millisecond)
+	}
+	v := rid.Load()
+	if v == nil {
+		t.Fatal("run id not captured")
+	}
+	runID, _ := v.(string)
+	if runID == "" {
+		t.Fatal("empty run id")
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	if got := processed.Load(); got != 0 {
+		t.Fatalf("expected no processing while paused, got %d", got)
+	}
+
+	if !iruntime.ResumeRun(runID) {
+		t.Fatal("expected resume to succeed")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected run error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not complete after resume")
+	}
+	if got := processed.Load(); got != 5 {
+		t.Fatalf("processed=%d want=5", got)
 	}
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -2121,6 +2121,138 @@ func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
 	}
 }
 
+func TestRunFrontierPauseResumeIdempotentDuringRun(t *testing.T) {
+	p := NewPipeline[int]()
+	var processed atomic.Int64
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			time.Sleep(2 * time.Millisecond)
+			processed.Add(1)
+			return []int{in}, nil
+		},
+	})
+
+	done := make(chan error, 1)
+	var rid atomic.Value
+	go func() {
+		_, err := p.Run(
+			context.Background(),
+			map[string][]int{"a": {1, 2, 3, 4, 5, 6, 7, 8}},
+			WithFrontier[int](true),
+			WithHooks[int](Hooks[int]{
+				RunStart: func(ctx context.Context, meta RunMeta) {
+					rid.Store(meta.RunID)
+					_ = iruntime.PauseRun(meta.RunID)
+				},
+			}),
+		)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for rid.Load() == nil && time.Now().Before(deadline) {
+		time.Sleep(1 * time.Millisecond)
+	}
+	v := rid.Load()
+	if v == nil {
+		t.Fatal("run id not captured")
+	}
+	runID, _ := v.(string)
+	if runID == "" {
+		t.Fatal("empty run id")
+	}
+
+	// Already paused in RunStart; repeated pause is idempotent.
+	if iruntime.PauseRun(runID) {
+		t.Fatal("expected repeated pause to be idempotent no-op")
+	}
+	time.Sleep(20 * time.Millisecond)
+	if !iruntime.ResumeRun(runID) {
+		t.Fatal("expected first resume to succeed")
+	}
+	if iruntime.ResumeRun(runID) {
+		t.Fatal("expected second resume to be idempotent no-op")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected run error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not complete")
+	}
+	if got := processed.Load(); got != 8 {
+		t.Fatalf("processed=%d want=8", got)
+	}
+}
+
+func TestRunFrontierCancelByRunIDIsIdempotent(t *testing.T) {
+	p := NewPipeline[int]()
+	_ = p.AddStage(testStage[int]{
+		name:    "a",
+		workers: 1,
+		fn: func(ctx context.Context, in int) ([]int, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(20 * time.Millisecond):
+				return []int{in}, nil
+			}
+		},
+	})
+
+	done := make(chan error, 1)
+	var rid atomic.Value
+	go func() {
+		_, err := p.Run(
+			context.Background(),
+			map[string][]int{"a": {1, 2, 3, 4, 5, 6, 7, 8}},
+			WithFrontier[int](true),
+			WithHooks[int](Hooks[int]{
+				RunStart: func(ctx context.Context, meta RunMeta) {
+					rid.Store(meta.RunID)
+				},
+			}),
+		)
+		done <- err
+	}()
+
+	deadline := time.Now().Add(1 * time.Second)
+	for rid.Load() == nil && time.Now().Before(deadline) {
+		time.Sleep(1 * time.Millisecond)
+	}
+	v := rid.Load()
+	if v == nil {
+		t.Fatal("run id not captured")
+	}
+	runID, _ := v.(string)
+	if runID == "" {
+		t.Fatal("empty run id")
+	}
+
+	if !iruntime.CancelRun(runID) {
+		t.Fatal("expected first cancel to succeed")
+	}
+	if iruntime.CancelRun(runID) {
+		t.Fatal("expected second cancel to be idempotent no-op")
+	}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected cancellation error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not finish after cancel")
+	}
+}
+
 type plainStoreNoStatsProvider struct {
 	base frontier.Store[int]
 }


### PR DESCRIPTION
## Summary

This PR adds internal session-runtime foundations for durable runs: explicit requeue policy defaults, durable status snapshots, runtime status emission from durable
stores, and internal pause/resume/cancel control plumbing.
Public API remains unchanged.

## Commits

- 5158f18 Add durable requeue policy constants and use default requeue limit
- c02063d Add durable requeue-expired idempotency and lease-expiry tests
- 60aa58f Add durable status snapshot API and SQLite state-count implementation
- 6744e2d Emit frontier stats from durable status provider via runtime helper
- 900d206 Add internal RunHandle skeleton with idempotent state transitions
- 4275f6d Wire internal RunHandle lifecycle state updates in Pipeline.Run
- 62e607e Add internal run registry and pause-gated frontier scheduler dispatch
- 5d0f4e5 Add idempotency integration tests for pause resume and cancel run controls

## What Changed

### Durable policy defaults

- Added durable runtime constants in internal/frontier/durable.go:
    - DefaultDurableLeaseTTL
    - DefaultRequeueExpiredLimit
- Replaced hardcoded requeue limit usage in pipeline frontier setup.

### Durable requeue reliability tests

- Extended SQLite durable frontier tests to verify:
    - requeue idempotency without new reserve cycle,
    - once-per-lease-cycle requeue behavior,
    - no-op before lease expiry.

### Durable status snapshots

- Added internal durable snapshot surface:
    - DurableStatusSnapshot
    - DurableStatusProvider
- Implemented StatusSnapshot(ctx) for SQLite durable store with compatibility-safe SQL:
    - COALESCE(SUM(CASE ...), 0) aggregation
- Added snapshot tests:
    - empty snapshot
    - mixed state counts + retried entries.

### Runtime status helper + hook emission

- Added internal/runtime/status.go:
    - TryDurableStatusSnapshot(...)
    - DurableSnapshotToStats(...)
- In Pipeline.Run frontier stats path:
    - if StatsProvider exists, existing behavior unchanged,
    - else if DurableStatusProvider exists, emit FrontierStats from durable snapshot on interval.
- Durable snapshot fetch errors are routed through existing runtime error policy path.

### Internal run control scaffolding

- Added internal RunHandle with idempotent transitions:
    - Pause, Resume, Cancel, MarkCompleted, Status
- Wired run handle lifecycle updates in Pipeline.Run.
- Added internal run registry:
    - register/unregister by run_id
    - PauseRun, ResumeRun, CancelRun, RunStatusByID
- Added pause gating to frontier scheduler dispatch loop:
    - ShouldPause callback
    - PausePoll interval

### Integration tests for control idempotency

- Added pipeline integration tests validating:
    - pause/resume idempotency during active frontier run,
    - cancel-by-run-id idempotency and cancellation outcome.

## Behavior / Compatibility

- No public API changes.
- Session runtime controls are internal-only (internal/runtime).
- Existing Pipeline.Run external contract remains intact.

## Validation

- go test ./... passes.
- Recommended pre-merge:
    - go test -race ./...

