### PR TITLE
Session runtime controls + telemetry/status public boundary

### DIFF
--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -125,3 +125,37 @@ if tm.PauseCount != 1 || tm.ResumeCount != 1 {
 active := pipex.GetRunTelemetrySnapshot(true) // excludes canceled/completed
 all := pipex.GetRunTelemetrySnapshot(false)   // includes terminal runs
 ```
+
+## Public Run Control and Status APIs
+
+For integration boundaries (such as `penta`), prefer public `pipex` APIs by
+`run_id`:
+
+- `pipex.PauseRun(runID) bool`
+- `pipex.ResumeRun(runID) bool`
+- `pipex.CancelRun(runID) bool`
+- `pipex.PauseRunE(runID) (bool, error)`
+- `pipex.ResumeRunE(runID) (bool, error)`
+- `pipex.CancelRunE(runID) (bool, error)`
+- `pipex.GetRunStatus(runID) (pipex.RunStatus, bool)`
+
+`GetRunStatus` is a lightweight polling shape:
+
+```go
+type RunStatus struct {
+	RunID     string
+	State     RunState // running|paused|canceled|completed
+	UpdatedAt time.Time
+}
+```
+
+### Control API Outcomes (`*E` variants)
+
+`PauseRunE`, `ResumeRunE`, and `CancelRunE` distinguish "unknown run" from
+"known run but no state transition":
+
+| Case | Return |
+| --- | --- |
+| Unknown `run_id` | `changed=false`, `err=pipex.ErrRunNotFound` |
+| Known `run_id`, idempotent no-op (already in target/terminal state) | `changed=false`, `err=nil` |
+| Known `run_id`, state transitioned | `changed=true`, `err=nil` |

--- a/docs/session-runtime.md
+++ b/docs/session-runtime.md
@@ -87,3 +87,41 @@ These can remain internal until semantics stabilize.
 - Define durable lease-expiry requeue policy constants and tests.
 - Add internal run status snapshot aggregation for durable frontier stores.
 - Validate resume idempotency under repeated calls and partial failures.
+
+## Public Test-Facing Telemetry
+
+`pipex` now exposes run lifecycle telemetry lookups on the public package so
+external integration tests (for example, `penta`) can assert pause/resume
+behavior by `run_id` without importing internal packages.
+
+### Capture `run_id` from hooks
+
+```go
+var runID string
+
+_, _ = p.Run(ctx, seeds, pipex.WithHooks(pipex.Hooks[Item]{
+	RunStart: func(_ context.Context, meta pipex.RunMeta) {
+		runID = meta.RunID
+	},
+}))
+```
+
+### Query per-run telemetry
+
+```go
+tm, ok := pipex.GetRunTelemetry(runID)
+if !ok {
+	t.Fatalf("missing run telemetry for run_id=%s", runID)
+}
+
+if tm.PauseCount != 1 || tm.ResumeCount != 1 {
+	t.Fatalf("unexpected pause/resume counts: %+v", tm)
+}
+```
+
+### Query all tracked runs
+
+```go
+active := pipex.GetRunTelemetrySnapshot(true) // excludes canceled/completed
+all := pipex.GetRunTelemetrySnapshot(false)   // includes terminal runs
+```

--- a/errors.go
+++ b/errors.go
@@ -12,6 +12,7 @@ var (
 	ErrStageNotFound  = errors.New("stage not found")
 	ErrStageExists    = errors.New("stage already exists")
 	ErrStageConflict  = errors.New("stage definition conflict")
+	ErrRunNotFound    = errors.New("run not found")
 
 	ErrStageInvalidWorkerCount = func(name string, count int) error {
 		return fmt.Errorf("invalid worker count for stage %s: %d", name, count)

--- a/internal/runtime/run_handle.go
+++ b/internal/runtime/run_handle.go
@@ -44,15 +44,30 @@ type RunHandle struct {
 	totalPaused time.Duration
 	pausedSince time.Time
 	hooks       RunHandleHooks
+
+	hookEvents chan runHookEvent
+	hookWG     sync.WaitGroup
+	hookStop   sync.Once
 }
 
 func NewRunHandle(runID string, cancel context.CancelFunc) *RunHandle {
-	return &RunHandle{
+	h := &RunHandle{
 		runID:  runID,
 		state:  RunStateRunning,
 		now:    time.Now,
 		cancel: cancel,
+		// Control transitions are low frequency; this buffer avoids blocking
+		// most call paths while preserving FIFO hook order.
+		hookEvents: make(chan runHookEvent, 64),
 	}
+	h.hookWG.Add(1)
+	go func() {
+		defer h.hookWG.Done()
+		for ev := range h.hookEvents {
+			h.dispatchHookEvent(ev)
+		}
+	}()
+	return h
 }
 
 func (h *RunHandle) SetCancel(cancel context.CancelFunc) {
@@ -78,11 +93,11 @@ func (h *RunHandle) Pause() bool {
 	h.pauseCount++
 	h.pausedSince = h.now()
 	snap := h.statusLocked(h.now())
-	onPause := h.hooks.OnPause
+	h.emitHookEventLocked(runHookEvent{
+		kind: runHookPause,
+		snap: snap,
+	})
 	h.mu.Unlock()
-	if onPause != nil {
-		onPause(snap)
-	}
 	return true
 }
 
@@ -100,11 +115,11 @@ func (h *RunHandle) Resume() bool {
 	h.resumeCount++
 	h.state = RunStateRunning
 	snap := h.statusLocked(h.now())
-	onResume := h.hooks.OnResume
+	h.emitHookEventLocked(runHookEvent{
+		kind: runHookResume,
+		snap: snap,
+	})
 	h.mu.Unlock()
-	if onResume != nil {
-		onResume(snap)
-	}
 	return true
 }
 
@@ -128,6 +143,7 @@ func (h *RunHandle) Cancel() bool {
 	if cancel != nil {
 		cancel()
 	}
+	h.stopHookDispatcher()
 	return true
 }
 
@@ -144,6 +160,7 @@ func (h *RunHandle) MarkCompleted() bool {
 		h.pausedSince = time.Time{}
 	}
 	h.state = RunStateCompleted
+	go h.stopHookDispatcher()
 	return true
 }
 
@@ -167,4 +184,45 @@ func (h *RunHandle) statusLocked(now time.Time) RunStatus {
 		status.CurrentPauseStart = h.pausedSince
 	}
 	return status
+}
+
+type runHookKind int
+
+const (
+	runHookPause runHookKind = iota
+	runHookResume
+)
+
+type runHookEvent struct {
+	kind runHookKind
+	snap RunStatus
+}
+
+func (h *RunHandle) emitHookEventLocked(ev runHookEvent) {
+	// Called with h.mu held so transition order maps to channel send order.
+	h.hookEvents <- ev
+}
+
+func (h *RunHandle) dispatchHookEvent(ev runHookEvent) {
+	h.mu.Lock()
+	hooks := h.hooks
+	h.mu.Unlock()
+
+	switch ev.kind {
+	case runHookPause:
+		if hooks.OnPause != nil {
+			hooks.OnPause(ev.snap)
+		}
+	case runHookResume:
+		if hooks.OnResume != nil {
+			hooks.OnResume(ev.snap)
+		}
+	}
+}
+
+func (h *RunHandle) stopHookDispatcher() {
+	h.hookStop.Do(func() {
+		close(h.hookEvents)
+		h.hookWG.Wait()
+	})
 }

--- a/internal/runtime/run_handle.go
+++ b/internal/runtime/run_handle.go
@@ -16,19 +16,34 @@ const (
 )
 
 type RunStatus struct {
-	RunID     string
-	State     RunState
-	UpdatedAt time.Time
+	RunID             string
+	State             RunState
+	UpdatedAt         time.Time
+	PauseCount        int64
+	ResumeCount       int64
+	TotalPaused       time.Duration
+	CurrentlyPaused   bool
+	CurrentPauseStart time.Time
+}
+
+type RunHandleHooks struct {
+	OnPause  func(RunStatus)
+	OnResume func(RunStatus)
 }
 
 // RunHandle is an internal control surface for run lifecycle state.
 // It is intentionally minimal and does not yet drive scheduler behavior.
 type RunHandle struct {
-	mu     sync.Mutex
-	runID  string
-	state  RunState
-	now    func() time.Time
-	cancel context.CancelFunc
+	mu          sync.Mutex
+	runID       string
+	state       RunState
+	now         func() time.Time
+	cancel      context.CancelFunc
+	pauseCount  int64
+	resumeCount int64
+	totalPaused time.Duration
+	pausedSince time.Time
+	hooks       RunHandleHooks
 }
 
 func NewRunHandle(runID string, cancel context.CancelFunc) *RunHandle {
@@ -46,25 +61,50 @@ func (h *RunHandle) SetCancel(cancel context.CancelFunc) {
 	h.cancel = cancel
 }
 
+func (h *RunHandle) SetHooks(hooks RunHandleHooks) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hooks = hooks
+}
+
 // Pause transitions running -> paused. Returns true when state changed.
 func (h *RunHandle) Pause() bool {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if h.state != RunStateRunning {
+		h.mu.Unlock()
 		return false
 	}
 	h.state = RunStatePaused
+	h.pauseCount++
+	h.pausedSince = h.now()
+	snap := h.statusLocked(h.now())
+	onPause := h.hooks.OnPause
+	h.mu.Unlock()
+	if onPause != nil {
+		onPause(snap)
+	}
 	return true
 }
 
 // Resume transitions paused -> running. Returns true when state changed.
 func (h *RunHandle) Resume() bool {
 	h.mu.Lock()
-	defer h.mu.Unlock()
 	if h.state != RunStatePaused {
+		h.mu.Unlock()
 		return false
 	}
+	if !h.pausedSince.IsZero() {
+		h.totalPaused += h.now().Sub(h.pausedSince)
+	}
+	h.pausedSince = time.Time{}
+	h.resumeCount++
 	h.state = RunStateRunning
+	snap := h.statusLocked(h.now())
+	onResume := h.hooks.OnResume
+	h.mu.Unlock()
+	if onResume != nil {
+		onResume(snap)
+	}
 	return true
 }
 
@@ -76,6 +116,10 @@ func (h *RunHandle) Cancel() bool {
 	if !changed {
 		h.mu.Unlock()
 		return false
+	}
+	if h.state == RunStatePaused && !h.pausedSince.IsZero() {
+		h.totalPaused += h.now().Sub(h.pausedSince)
+		h.pausedSince = time.Time{}
 	}
 	h.state = RunStateCanceled
 	cancel := h.cancel
@@ -95,6 +139,10 @@ func (h *RunHandle) MarkCompleted() bool {
 	if h.state == RunStateCompleted || h.state == RunStateCanceled {
 		return false
 	}
+	if h.state == RunStatePaused && !h.pausedSince.IsZero() {
+		h.totalPaused += h.now().Sub(h.pausedSince)
+		h.pausedSince = time.Time{}
+	}
 	h.state = RunStateCompleted
 	return true
 }
@@ -102,9 +150,21 @@ func (h *RunHandle) MarkCompleted() bool {
 func (h *RunHandle) Status() RunStatus {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return RunStatus{
-		RunID:     h.runID,
-		State:     h.state,
-		UpdatedAt: h.now(),
+	return h.statusLocked(h.now())
+}
+
+func (h *RunHandle) statusLocked(now time.Time) RunStatus {
+	status := RunStatus{
+		RunID:       h.runID,
+		State:       h.state,
+		UpdatedAt:   now,
+		PauseCount:  h.pauseCount,
+		ResumeCount: h.resumeCount,
+		TotalPaused: h.totalPaused,
 	}
+	if h.state == RunStatePaused && !h.pausedSince.IsZero() {
+		status.CurrentlyPaused = true
+		status.CurrentPauseStart = h.pausedSince
+	}
+	return status
 }

--- a/internal/runtime/run_handle_test.go
+++ b/internal/runtime/run_handle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestRunHandle_PauseResumeIdempotent(t *testing.T) {
@@ -27,6 +28,10 @@ func TestRunHandle_PauseResumeIdempotent(t *testing.T) {
 	}
 	if got := h.Status().State; got != RunStateRunning {
 		t.Fatalf("state=%s want=%s", got, RunStateRunning)
+	}
+	st := h.Status()
+	if st.PauseCount != 1 || st.ResumeCount != 1 {
+		t.Fatalf("pause/resume counts mismatch: %+v", st)
 	}
 }
 
@@ -73,5 +78,57 @@ func TestRunHandle_CompletedTerminal(t *testing.T) {
 	}
 	if got := h.Status().State; got != RunStateCompleted {
 		t.Fatalf("state=%s want=%s", got, RunStateCompleted)
+	}
+}
+
+func TestRunHandle_PauseDurationTelemetry(t *testing.T) {
+	h := NewRunHandle("r4", nil)
+	base := time.Unix(1700000000, 0)
+	now := base
+	h.now = func() time.Time { return now }
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	now = now.Add(250 * time.Millisecond)
+	if !h.Resume() {
+		t.Fatal("resume should succeed")
+	}
+
+	st := h.Status()
+	if st.TotalPaused != 250*time.Millisecond {
+		t.Fatalf("total paused=%s want=%s", st.TotalPaused, 250*time.Millisecond)
+	}
+	if st.PauseCount != 1 || st.ResumeCount != 1 {
+		t.Fatalf("unexpected counts: %+v", st)
+	}
+}
+
+func TestRunHandle_PauseResumeHooks(t *testing.T) {
+	h := NewRunHandle("r5", nil)
+	var paused, resumed atomic.Int64
+	h.SetHooks(RunHandleHooks{
+		OnPause: func(st RunStatus) {
+			paused.Add(1)
+			if st.State != RunStatePaused {
+				t.Fatalf("pause hook state=%s", st.State)
+			}
+		},
+		OnResume: func(st RunStatus) {
+			resumed.Add(1)
+			if st.State != RunStateRunning {
+				t.Fatalf("resume hook state=%s", st.State)
+			}
+		},
+	})
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	if !h.Resume() {
+		t.Fatal("resume should succeed")
+	}
+	if paused.Load() != 1 || resumed.Load() != 1 {
+		t.Fatalf("unexpected hook counts paused=%d resumed=%d", paused.Load(), resumed.Load())
 	}
 }

--- a/internal/runtime/run_handle_test.go
+++ b/internal/runtime/run_handle_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -107,18 +108,21 @@ func TestRunHandle_PauseDurationTelemetry(t *testing.T) {
 func TestRunHandle_PauseResumeHooks(t *testing.T) {
 	h := NewRunHandle("r5", nil)
 	var paused, resumed atomic.Int64
+	done := make(chan struct{}, 2)
 	h.SetHooks(RunHandleHooks{
 		OnPause: func(st RunStatus) {
 			paused.Add(1)
 			if st.State != RunStatePaused {
 				t.Fatalf("pause hook state=%s", st.State)
 			}
+			done <- struct{}{}
 		},
 		OnResume: func(st RunStatus) {
 			resumed.Add(1)
 			if st.State != RunStateRunning {
 				t.Fatalf("resume hook state=%s", st.State)
 			}
+			done <- struct{}{}
 		},
 	})
 
@@ -128,7 +132,68 @@ func TestRunHandle_PauseResumeHooks(t *testing.T) {
 	if !h.Resume() {
 		t.Fatal("resume should succeed")
 	}
+	waitForN(t, done, 2, time.Second)
 	if paused.Load() != 1 || resumed.Load() != 1 {
 		t.Fatalf("unexpected hook counts paused=%d resumed=%d", paused.Load(), resumed.Load())
+	}
+}
+
+func TestRunHandle_HookOrderConcurrentPauseResume(t *testing.T) {
+	h := NewRunHandle("r6", nil)
+	var (
+		mu     sync.Mutex
+		events []RunState
+	)
+	done := make(chan struct{}, 2)
+	h.SetHooks(RunHandleHooks{
+		OnPause: func(st RunStatus) {
+			mu.Lock()
+			events = append(events, st.State)
+			mu.Unlock()
+			done <- struct{}{}
+		},
+		OnResume: func(st RunStatus) {
+			mu.Lock()
+			events = append(events, st.State)
+			mu.Unlock()
+			done <- struct{}{}
+		},
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_ = h.Pause()
+	}()
+	go func() {
+		defer wg.Done()
+		deadline := time.Now().Add(200 * time.Millisecond)
+		for !h.Resume() && time.Now().Before(deadline) {
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+	wg.Wait()
+	waitForN(t, done, 2, time.Second)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d (%v)", len(events), events)
+	}
+	if events[0] != RunStatePaused || events[1] != RunStateRunning {
+		t.Fatalf("unexpected hook order: %v", events)
+	}
+}
+
+func waitForN(t *testing.T, ch <-chan struct{}, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for i := 0; i < n; i++ {
+		select {
+		case <-ch:
+		case <-deadline:
+			t.Fatalf("timeout waiting for %d events (received %d)", n, i)
+		}
 	}
 }

--- a/internal/runtime/run_telemetry.go
+++ b/internal/runtime/run_telemetry.go
@@ -1,0 +1,31 @@
+package runtime
+
+import "time"
+
+type RunTelemetry struct {
+	RunID             string
+	PauseCount        int64
+	ResumeCount       int64
+	TotalPaused       time.Duration
+	CurrentlyPaused   bool
+	CurrentPauseStart time.Time
+	LastState         RunState
+	UpdatedAt         time.Time
+}
+
+func RunTelemetryByID(runID string) (RunTelemetry, bool) {
+	st, ok := RunStatusByID(runID)
+	if !ok {
+		return RunTelemetry{}, false
+	}
+	return RunTelemetry{
+		RunID:             st.RunID,
+		PauseCount:        st.PauseCount,
+		ResumeCount:       st.ResumeCount,
+		TotalPaused:       st.TotalPaused,
+		CurrentlyPaused:   st.CurrentlyPaused,
+		CurrentPauseStart: st.CurrentPauseStart,
+		LastState:         st.State,
+		UpdatedAt:         st.UpdatedAt,
+	}, true
+}

--- a/internal/runtime/run_telemetry.go
+++ b/internal/runtime/run_telemetry.go
@@ -18,6 +18,33 @@ func RunTelemetryByID(runID string) (RunTelemetry, bool) {
 	if !ok {
 		return RunTelemetry{}, false
 	}
+	return runStatusToTelemetry(st), true
+}
+
+// RunTelemetrySnapshot returns a copy of run telemetry keyed by run_id.
+// When activeOnly is true, terminal runs (completed/canceled) are excluded.
+func RunTelemetrySnapshot(activeOnly bool) map[string]RunTelemetry {
+	out := make(map[string]RunTelemetry)
+	runHandleRegistry.Range(func(key, value any) bool {
+		runID, ok := key.(string)
+		if !ok {
+			return true
+		}
+		h, ok := value.(*RunHandle)
+		if !ok {
+			return true
+		}
+		st := h.Status()
+		if activeOnly && isTerminalRunState(st.State) {
+			return true
+		}
+		out[runID] = runStatusToTelemetry(st)
+		return true
+	})
+	return out
+}
+
+func runStatusToTelemetry(st RunStatus) RunTelemetry {
 	return RunTelemetry{
 		RunID:             st.RunID,
 		PauseCount:        st.PauseCount,
@@ -27,5 +54,9 @@ func RunTelemetryByID(runID string) (RunTelemetry, bool) {
 		CurrentPauseStart: st.CurrentPauseStart,
 		LastState:         st.State,
 		UpdatedAt:         st.UpdatedAt,
-	}, true
+	}
+}
+
+func isTerminalRunState(state RunState) bool {
+	return state == RunStateCanceled || state == RunStateCompleted
 }

--- a/internal/runtime/run_telemetry_test.go
+++ b/internal/runtime/run_telemetry_test.go
@@ -74,3 +74,66 @@ func TestRunTelemetryByID_CurrentlyPausedFields(t *testing.T) {
 		t.Fatalf("last state=%s want=%s", tm.LastState, RunStatePaused)
 	}
 }
+
+func TestRunTelemetrySnapshot_AllRuns(t *testing.T) {
+	running := NewRunHandle("snap-running", nil)
+	paused := NewRunHandle("snap-paused", nil)
+	completed := NewRunHandle("snap-completed", nil)
+	RegisterRunHandle("snap-running", running)
+	RegisterRunHandle("snap-paused", paused)
+	RegisterRunHandle("snap-completed", completed)
+	defer UnregisterRunHandle("snap-running")
+	defer UnregisterRunHandle("snap-paused")
+	defer UnregisterRunHandle("snap-completed")
+
+	if !paused.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	if !completed.MarkCompleted() {
+		t.Fatal("mark completed should succeed")
+	}
+
+	snap := RunTelemetrySnapshot(false)
+	if len(snap) != 3 {
+		t.Fatalf("snapshot size=%d want=3", len(snap))
+	}
+	if snap["snap-running"].LastState != RunStateRunning {
+		t.Fatalf("running state=%s want=%s", snap["snap-running"].LastState, RunStateRunning)
+	}
+	if snap["snap-paused"].LastState != RunStatePaused {
+		t.Fatalf("paused state=%s want=%s", snap["snap-paused"].LastState, RunStatePaused)
+	}
+	if snap["snap-completed"].LastState != RunStateCompleted {
+		t.Fatalf("completed state=%s want=%s", snap["snap-completed"].LastState, RunStateCompleted)
+	}
+}
+
+func TestRunTelemetrySnapshot_ActiveOnly(t *testing.T) {
+	running := NewRunHandle("active-running", nil)
+	paused := NewRunHandle("active-paused", nil)
+	canceled := NewRunHandle("active-canceled", nil)
+	RegisterRunHandle("active-running", running)
+	RegisterRunHandle("active-paused", paused)
+	RegisterRunHandle("active-canceled", canceled)
+	defer UnregisterRunHandle("active-running")
+	defer UnregisterRunHandle("active-paused")
+	defer UnregisterRunHandle("active-canceled")
+
+	if !paused.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	if !canceled.Cancel() {
+		t.Fatal("cancel should succeed")
+	}
+
+	snap := RunTelemetrySnapshot(true)
+	if _, ok := snap["active-canceled"]; ok {
+		t.Fatal("expected canceled run to be excluded for activeOnly")
+	}
+	if _, ok := snap["active-running"]; !ok {
+		t.Fatal("expected running run in activeOnly snapshot")
+	}
+	if _, ok := snap["active-paused"]; !ok {
+		t.Fatal("expected paused run in activeOnly snapshot")
+	}
+}

--- a/internal/runtime/run_telemetry_test.go
+++ b/internal/runtime/run_telemetry_test.go
@@ -1,0 +1,76 @@
+package runtime
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRunTelemetryByID_Present(t *testing.T) {
+	h := NewRunHandle("telemetry-run", nil)
+	base := time.Unix(1700001000, 0)
+	now := base
+	h.now = func() time.Time { return now }
+	RegisterRunHandle("telemetry-run", h)
+	defer UnregisterRunHandle("telemetry-run")
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	now = now.Add(100 * time.Millisecond)
+	if !h.Resume() {
+		t.Fatal("resume should succeed")
+	}
+
+	tm, ok := RunTelemetryByID("telemetry-run")
+	if !ok {
+		t.Fatal("expected telemetry to exist")
+	}
+	if tm.RunID != "telemetry-run" {
+		t.Fatalf("run id=%s", tm.RunID)
+	}
+	if tm.PauseCount != 1 || tm.ResumeCount != 1 {
+		t.Fatalf("unexpected counts: %+v", tm)
+	}
+	if tm.TotalPaused != 100*time.Millisecond {
+		t.Fatalf("total paused=%s want=%s", tm.TotalPaused, 100*time.Millisecond)
+	}
+	if tm.CurrentlyPaused {
+		t.Fatal("expected currently paused=false after resume")
+	}
+	if tm.LastState != RunStateRunning {
+		t.Fatalf("last state=%s want=%s", tm.LastState, RunStateRunning)
+	}
+}
+
+func TestRunTelemetryByID_Missing(t *testing.T) {
+	_, ok := RunTelemetryByID("missing-run")
+	if ok {
+		t.Fatal("expected missing telemetry lookup to fail")
+	}
+}
+
+func TestRunTelemetryByID_CurrentlyPausedFields(t *testing.T) {
+	h := NewRunHandle("paused-run", nil)
+	base := time.Unix(1700002000, 0)
+	now := base
+	h.now = func() time.Time { return now }
+	RegisterRunHandle("paused-run", h)
+	defer UnregisterRunHandle("paused-run")
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	tm, ok := RunTelemetryByID("paused-run")
+	if !ok {
+		t.Fatal("expected telemetry to exist")
+	}
+	if !tm.CurrentlyPaused {
+		t.Fatal("expected currently paused=true")
+	}
+	if tm.CurrentPauseStart.IsZero() {
+		t.Fatal("expected current pause start to be set")
+	}
+	if tm.LastState != RunStatePaused {
+		t.Fatalf("last state=%s want=%s", tm.LastState, RunStatePaused)
+	}
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -2121,7 +2121,7 @@ func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
 	deadline = time.Now().Add(1 * time.Second)
 	for time.Now().Before(deadline) {
 		telemetry, ok = GetRunTelemetry(runID)
-		if ok && telemetry.ResumeCount >= 1 && telemetry.LastState == "running" && !telemetry.CurrentlyPaused {
+		if ok && telemetry.ResumeCount >= 1 && telemetry.LastState == RunStateRunning && !telemetry.CurrentlyPaused {
 			break
 		}
 		time.Sleep(1 * time.Millisecond)
@@ -2132,7 +2132,7 @@ func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
 	if telemetry.ResumeCount < 1 {
 		t.Fatalf("expected resume count to increment, got %d", telemetry.ResumeCount)
 	}
-	if telemetry.LastState != "running" {
+	if telemetry.LastState != RunStateRunning {
 		t.Fatalf("expected running state after resume, got %s", telemetry.LastState)
 	}
 	if telemetry.CurrentlyPaused {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ruohao1/pipex/internal/frontier"
-	iruntime "github.com/ruohao1/pipex/internal/runtime"
 )
 
 type testStage[T any] struct {
@@ -2079,7 +2078,7 @@ func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
 			WithHooks[int](Hooks[int]{
 				RunStart: func(ctx context.Context, meta RunMeta) {
 					rid.Store(meta.RunID)
-					_ = iruntime.PauseRun(meta.RunID)
+					_ = PauseRun(meta.RunID)
 				},
 			}),
 		)
@@ -2104,8 +2103,40 @@ func TestRunFrontierPauseResumeGatesSchedulerDispatch(t *testing.T) {
 		t.Fatalf("expected no processing while paused, got %d", got)
 	}
 
-	if !iruntime.ResumeRun(runID) {
+	telemetry, ok := GetRunTelemetry(runID)
+	if !ok {
+		t.Fatal("expected telemetry for active run")
+	}
+	if telemetry.PauseCount != 1 || telemetry.ResumeCount != 0 {
+		t.Fatalf("unexpected pause/resume counts while paused: %+v", telemetry)
+	}
+	if !telemetry.CurrentlyPaused {
+		t.Fatal("expected currently paused telemetry state")
+	}
+
+	if !ResumeRun(runID) {
 		t.Fatal("expected resume to succeed")
+	}
+
+	deadline = time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		telemetry, ok = GetRunTelemetry(runID)
+		if ok && telemetry.ResumeCount >= 1 && telemetry.LastState == "running" && !telemetry.CurrentlyPaused {
+			break
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	if !ok {
+		t.Fatal("expected telemetry after resume before run exit")
+	}
+	if telemetry.ResumeCount < 1 {
+		t.Fatalf("expected resume count to increment, got %d", telemetry.ResumeCount)
+	}
+	if telemetry.LastState != "running" {
+		t.Fatalf("expected running state after resume, got %s", telemetry.LastState)
+	}
+	if telemetry.CurrentlyPaused {
+		t.Fatal("expected currently paused=false after resume")
 	}
 
 	select {
@@ -2144,7 +2175,7 @@ func TestRunFrontierPauseResumeIdempotentDuringRun(t *testing.T) {
 			WithHooks[int](Hooks[int]{
 				RunStart: func(ctx context.Context, meta RunMeta) {
 					rid.Store(meta.RunID)
-					_ = iruntime.PauseRun(meta.RunID)
+					_ = PauseRun(meta.RunID)
 				},
 			}),
 		)
@@ -2165,14 +2196,14 @@ func TestRunFrontierPauseResumeIdempotentDuringRun(t *testing.T) {
 	}
 
 	// Already paused in RunStart; repeated pause is idempotent.
-	if iruntime.PauseRun(runID) {
+	if PauseRun(runID) {
 		t.Fatal("expected repeated pause to be idempotent no-op")
 	}
 	time.Sleep(20 * time.Millisecond)
-	if !iruntime.ResumeRun(runID) {
+	if !ResumeRun(runID) {
 		t.Fatal("expected first resume to succeed")
 	}
-	if iruntime.ResumeRun(runID) {
+	if ResumeRun(runID) {
 		t.Fatal("expected second resume to be idempotent no-op")
 	}
 
@@ -2233,10 +2264,10 @@ func TestRunFrontierCancelByRunIDIsIdempotent(t *testing.T) {
 		t.Fatal("empty run id")
 	}
 
-	if !iruntime.CancelRun(runID) {
+	if !CancelRun(runID) {
 		t.Fatal("expected first cancel to succeed")
 	}
-	if iruntime.CancelRun(runID) {
+	if CancelRun(runID) {
 		t.Fatal("expected second cancel to be idempotent no-op")
 	}
 

--- a/run_control.go
+++ b/run_control.go
@@ -1,0 +1,18 @@
+package pipex
+
+import iruntime "github.com/ruohao1/pipex/internal/runtime"
+
+// PauseRun pauses a running pipeline by run_id. It returns true when state changed.
+func PauseRun(runID string) bool {
+	return iruntime.PauseRun(runID)
+}
+
+// ResumeRun resumes a paused pipeline by run_id. It returns true when state changed.
+func ResumeRun(runID string) bool {
+	return iruntime.ResumeRun(runID)
+}
+
+// CancelRun cancels a pipeline by run_id. It returns true when state changed.
+func CancelRun(runID string) bool {
+	return iruntime.CancelRun(runID)
+}

--- a/run_control.go
+++ b/run_control.go
@@ -4,15 +4,45 @@ import iruntime "github.com/ruohao1/pipex/internal/runtime"
 
 // PauseRun pauses a running pipeline by run_id. It returns true when state changed.
 func PauseRun(runID string) bool {
-	return iruntime.PauseRun(runID)
+	changed, _ := PauseRunE(runID)
+	return changed
 }
 
 // ResumeRun resumes a paused pipeline by run_id. It returns true when state changed.
 func ResumeRun(runID string) bool {
-	return iruntime.ResumeRun(runID)
+	changed, _ := ResumeRunE(runID)
+	return changed
 }
 
 // CancelRun cancels a pipeline by run_id. It returns true when state changed.
 func CancelRun(runID string) bool {
-	return iruntime.CancelRun(runID)
+	changed, _ := CancelRunE(runID)
+	return changed
+}
+
+// PauseRunE pauses a running pipeline by run_id.
+// It returns ErrRunNotFound when run_id is unknown.
+func PauseRunE(runID string) (bool, error) {
+	if _, ok := iruntime.RunStatusByID(runID); !ok {
+		return false, ErrRunNotFound
+	}
+	return iruntime.PauseRun(runID), nil
+}
+
+// ResumeRunE resumes a paused pipeline by run_id.
+// It returns ErrRunNotFound when run_id is unknown.
+func ResumeRunE(runID string) (bool, error) {
+	if _, ok := iruntime.RunStatusByID(runID); !ok {
+		return false, ErrRunNotFound
+	}
+	return iruntime.ResumeRun(runID), nil
+}
+
+// CancelRunE cancels a pipeline by run_id.
+// It returns ErrRunNotFound when run_id is unknown.
+func CancelRunE(runID string) (bool, error) {
+	if _, ok := iruntime.RunStatusByID(runID); !ok {
+		return false, ErrRunNotFound
+	}
+	return iruntime.CancelRun(runID), nil
 }

--- a/run_control_test.go
+++ b/run_control_test.go
@@ -1,0 +1,39 @@
+package pipex
+
+import (
+	"errors"
+	"testing"
+
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
+)
+
+func TestRunControlE_NotFound(t *testing.T) {
+	if changed, err := PauseRunE("missing"); !errors.Is(err, ErrRunNotFound) || changed {
+		t.Fatalf("pause missing got changed=%v err=%v", changed, err)
+	}
+	if changed, err := ResumeRunE("missing"); !errors.Is(err, ErrRunNotFound) || changed {
+		t.Fatalf("resume missing got changed=%v err=%v", changed, err)
+	}
+	if changed, err := CancelRunE("missing"); !errors.Is(err, ErrRunNotFound) || changed {
+		t.Fatalf("cancel missing got changed=%v err=%v", changed, err)
+	}
+}
+
+func TestRunControlE_IdempotentNoop(t *testing.T) {
+	h := iruntime.NewRunHandle("control-idempotent", nil)
+	iruntime.RegisterRunHandle("control-idempotent", h)
+	defer iruntime.UnregisterRunHandle("control-idempotent")
+
+	changed, err := PauseRunE("control-idempotent")
+	if err != nil || !changed {
+		t.Fatalf("first pause got changed=%v err=%v", changed, err)
+	}
+
+	changed, err = PauseRunE("control-idempotent")
+	if err != nil {
+		t.Fatalf("second pause unexpected err=%v", err)
+	}
+	if changed {
+		t.Fatal("second pause should be idempotent no-op")
+	}
+}

--- a/run_status.go
+++ b/run_status.go
@@ -1,0 +1,27 @@
+package pipex
+
+import (
+	"time"
+
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
+)
+
+// RunStatus is a lightweight run status snapshot for frequent polling.
+type RunStatus struct {
+	RunID     string
+	State     RunState
+	UpdatedAt time.Time
+}
+
+// GetRunStatus returns run status for a run_id when it is currently tracked.
+func GetRunStatus(runID string) (RunStatus, bool) {
+	st, ok := iruntime.RunStatusByID(runID)
+	if !ok {
+		return RunStatus{}, false
+	}
+	return RunStatus{
+		RunID:     st.RunID,
+		State:     RunState(st.State),
+		UpdatedAt: st.UpdatedAt,
+	}, true
+}

--- a/run_status_test.go
+++ b/run_status_test.go
@@ -1,0 +1,37 @@
+package pipex
+
+import (
+	"testing"
+
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
+)
+
+func TestGetRunStatus_Present(t *testing.T) {
+	h := iruntime.NewRunHandle("status-run", nil)
+	iruntime.RegisterRunHandle("status-run", h)
+	defer iruntime.UnregisterRunHandle("status-run")
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+
+	st, ok := GetRunStatus("status-run")
+	if !ok {
+		t.Fatal("expected status to exist")
+	}
+	if st.RunID != "status-run" {
+		t.Fatalf("run id=%s", st.RunID)
+	}
+	if st.State != RunStatePaused {
+		t.Fatalf("state=%s want=%s", st.State, RunStatePaused)
+	}
+	if st.UpdatedAt.IsZero() {
+		t.Fatal("updated_at should be set")
+	}
+}
+
+func TestGetRunStatus_Missing(t *testing.T) {
+	if _, ok := GetRunStatus("missing-run"); ok {
+		t.Fatal("expected missing status to be absent")
+	}
+}

--- a/run_telemetry.go
+++ b/run_telemetry.go
@@ -1,0 +1,52 @@
+package pipex
+
+import (
+	"time"
+
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
+)
+
+// RunTelemetry is a public snapshot of run lifecycle telemetry.
+type RunTelemetry struct {
+	RunID             string
+	PauseCount        int64
+	ResumeCount       int64
+	TotalPaused       time.Duration
+	CurrentlyPaused   bool
+	CurrentPauseStart time.Time
+	LastState         string
+	UpdatedAt         time.Time
+}
+
+// GetRunTelemetry returns telemetry for a run_id when it is currently tracked.
+func GetRunTelemetry(runID string) (RunTelemetry, bool) {
+	tm, ok := iruntime.RunTelemetryByID(runID)
+	if !ok {
+		return RunTelemetry{}, false
+	}
+	return toPublicRunTelemetry(tm), true
+}
+
+// GetRunTelemetrySnapshot returns run telemetry keyed by run_id.
+// When activeOnly is true, terminal runs are excluded.
+func GetRunTelemetrySnapshot(activeOnly bool) map[string]RunTelemetry {
+	internal := iruntime.RunTelemetrySnapshot(activeOnly)
+	out := make(map[string]RunTelemetry, len(internal))
+	for runID, tm := range internal {
+		out[runID] = toPublicRunTelemetry(tm)
+	}
+	return out
+}
+
+func toPublicRunTelemetry(tm iruntime.RunTelemetry) RunTelemetry {
+	return RunTelemetry{
+		RunID:             tm.RunID,
+		PauseCount:        tm.PauseCount,
+		ResumeCount:       tm.ResumeCount,
+		TotalPaused:       tm.TotalPaused,
+		CurrentlyPaused:   tm.CurrentlyPaused,
+		CurrentPauseStart: tm.CurrentPauseStart,
+		LastState:         string(tm.LastState),
+		UpdatedAt:         tm.UpdatedAt,
+	}
+}

--- a/run_telemetry.go
+++ b/run_telemetry.go
@@ -6,6 +6,15 @@ import (
 	iruntime "github.com/ruohao1/pipex/internal/runtime"
 )
 
+type RunState string
+
+const (
+	RunStateRunning   RunState = "running"
+	RunStatePaused    RunState = "paused"
+	RunStateCanceled  RunState = "canceled"
+	RunStateCompleted RunState = "completed"
+)
+
 // RunTelemetry is a public snapshot of run lifecycle telemetry.
 type RunTelemetry struct {
 	RunID             string
@@ -14,7 +23,7 @@ type RunTelemetry struct {
 	TotalPaused       time.Duration
 	CurrentlyPaused   bool
 	CurrentPauseStart time.Time
-	LastState         string
+	LastState         RunState
 	UpdatedAt         time.Time
 }
 
@@ -46,7 +55,7 @@ func toPublicRunTelemetry(tm iruntime.RunTelemetry) RunTelemetry {
 		TotalPaused:       tm.TotalPaused,
 		CurrentlyPaused:   tm.CurrentlyPaused,
 		CurrentPauseStart: tm.CurrentPauseStart,
-		LastState:         string(tm.LastState),
+		LastState:         RunState(tm.LastState),
 		UpdatedAt:         tm.UpdatedAt,
 	}
 }

--- a/run_telemetry_test.go
+++ b/run_telemetry_test.go
@@ -31,8 +31,8 @@ func TestGetRunTelemetry_Present(t *testing.T) {
 	if tm.CurrentlyPaused {
 		t.Fatal("expected currently paused=false after resume")
 	}
-	if tm.LastState != "running" {
-		t.Fatalf("last state=%s want=running", tm.LastState)
+	if tm.LastState != RunStateRunning {
+		t.Fatalf("last state=%s want=%s", tm.LastState, RunStateRunning)
 	}
 }
 
@@ -60,5 +60,23 @@ func TestGetRunTelemetrySnapshot_ActiveOnly(t *testing.T) {
 	}
 	if _, ok := snap["public-active-running"]; !ok {
 		t.Fatal("expected running run to be included")
+	}
+}
+
+func TestGetRunTelemetry_AfterCancel(t *testing.T) {
+	h := iruntime.NewRunHandle("public-cancel-telemetry", nil)
+	iruntime.RegisterRunHandle("public-cancel-telemetry", h)
+	defer iruntime.UnregisterRunHandle("public-cancel-telemetry")
+
+	if !CancelRun("public-cancel-telemetry") {
+		t.Fatal("cancel should succeed")
+	}
+
+	tm, ok := GetRunTelemetry("public-cancel-telemetry")
+	if !ok {
+		t.Fatal("expected telemetry to remain queryable after cancel")
+	}
+	if tm.LastState != RunStateCanceled {
+		t.Fatalf("last state=%s want=%s", tm.LastState, RunStateCanceled)
 	}
 }

--- a/run_telemetry_test.go
+++ b/run_telemetry_test.go
@@ -1,0 +1,64 @@
+package pipex
+
+import (
+	"testing"
+
+	iruntime "github.com/ruohao1/pipex/internal/runtime"
+)
+
+func TestGetRunTelemetry_Present(t *testing.T) {
+	h := iruntime.NewRunHandle("public-telemetry-run", nil)
+	iruntime.RegisterRunHandle("public-telemetry-run", h)
+	defer iruntime.UnregisterRunHandle("public-telemetry-run")
+
+	if !h.Pause() {
+		t.Fatal("pause should succeed")
+	}
+	if !h.Resume() {
+		t.Fatal("resume should succeed")
+	}
+
+	tm, ok := GetRunTelemetry("public-telemetry-run")
+	if !ok {
+		t.Fatal("expected telemetry to exist")
+	}
+	if tm.RunID != "public-telemetry-run" {
+		t.Fatalf("run id=%s", tm.RunID)
+	}
+	if tm.PauseCount != 1 || tm.ResumeCount != 1 {
+		t.Fatalf("unexpected pause/resume counts: %+v", tm)
+	}
+	if tm.CurrentlyPaused {
+		t.Fatal("expected currently paused=false after resume")
+	}
+	if tm.LastState != "running" {
+		t.Fatalf("last state=%s want=running", tm.LastState)
+	}
+}
+
+func TestGetRunTelemetry_Missing(t *testing.T) {
+	if _, ok := GetRunTelemetry("missing-run"); ok {
+		t.Fatal("expected missing telemetry to be absent")
+	}
+}
+
+func TestGetRunTelemetrySnapshot_ActiveOnly(t *testing.T) {
+	running := iruntime.NewRunHandle("public-active-running", nil)
+	canceled := iruntime.NewRunHandle("public-active-canceled", nil)
+	iruntime.RegisterRunHandle("public-active-running", running)
+	iruntime.RegisterRunHandle("public-active-canceled", canceled)
+	defer iruntime.UnregisterRunHandle("public-active-running")
+	defer iruntime.UnregisterRunHandle("public-active-canceled")
+
+	if !canceled.Cancel() {
+		t.Fatal("cancel should succeed")
+	}
+
+	snap := GetRunTelemetrySnapshot(true)
+	if _, ok := snap["public-active-canceled"]; ok {
+		t.Fatal("expected canceled run to be filtered in activeOnly snapshot")
+	}
+	if _, ok := snap["public-active-running"]; !ok {
+		t.Fatal("expected running run to be included")
+	}
+}


### PR DESCRIPTION
## Summary

This PR completes the session-runtime boundary work so penta can control and observe runs by run_id without importing pipex/internal/*.

It adds:

- Public run controls by run_id (PauseRun, ResumeRun, CancelRun)
- Explicit error-returning control variants (PauseRunE, ResumeRunE, CancelRunE) with ErrRunNotFound
- Public lightweight run status polling (GetRunStatus)
- Public run telemetry APIs (GetRunTelemetry, GetRunTelemetrySnapshot)
- Internal runtime run-handle/registry/telemetry plumbing and durable status snapshot support
- Integration tests and docs for the new boundary

## Key Changes

### Public API

- Added run_control.go
    - PauseRun, ResumeRun, CancelRun
    - PauseRunE, ResumeRunE, CancelRunE
- Added run_status.go
    - GetRunStatus(runID)
- Added run_telemetry.go
    - GetRunTelemetry(runID)
    - GetRunTelemetrySnapshot(activeOnly)
    - Public RunState constants and typed RunTelemetry.LastState
- Added ErrRunNotFound in errors.go

### Internal Runtime

- Added internal run handle lifecycle model + ordered pause/resume hook emission
- Added run registry by run_id
- Added internal telemetry/status helpers
- Wired Pipeline.Run to register/unregister run handles and update lifecycle state
- Added durable frontier status snapshot provider support (including SQLite implementation/tests)
- Added durable requeue policy constants and lease-expiry/idempotency tests

### Tests

- Added/updated tests for:
    - run control idempotency and not-found semantics
    - pause/resume/cancel integration behavior by run_id
    - public telemetry and status lookups
    - active-only telemetry snapshots
    - durable status snapshot and error paths
    - hook ordering under concurrent pause/resume

## Semantics

For PauseRunE / ResumeRunE / CancelRunE:

- Unknown run_id -> changed=false, err=ErrRunNotFound
- Known run_id, idempotent no-op -> changed=false, err=nil
- Known run_id, state transition -> changed=true, err=nil

## Docs

- Updated docs/session-runtime.md with:
    - public control/status/telemetry usage
    - run_id capture via RunStart
    - control API outcome table

## Validation

- go test ./... passes
- go test -race ./... passes (verified during branch work)

## Notes

This PR intentionally keeps scanner-domain session semantics in penta and only exposes engine/runtime boundary primitives in pipex.